### PR TITLE
SSCS - 2697 Terraform doesn't support integer type.

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -67,7 +67,7 @@ variable "gaps2_sftp_host"{
   default = "sftp-dev.reform.hmcts.net"
 }
 variable "gaps2_sftp_port"{
-  default = "9000"
+  default = 9000
 }
 variable "gaps2_sftp_user"{
   default = "sscs-sftp-test"


### PR DESCRIPTION
So trying to define sftp port number with out quotes and see whether this will work.

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
