### PR TITLE
Sscs 2814 map hearing venue data

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/models/serialize/ccd/Address.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/models/serialize/ccd/Address.java
@@ -1,10 +1,16 @@
 package uk.gov.hmcts.reform.sscs.models.serialize.ccd;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 import lombok.Value;
 
 @Value
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Address {
+    private String line1;
+    private String line2;
+    private String town;
+    private String county;
     private String postcode;
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/models/serialize/ccd/Venue.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/models/serialize/ccd/Venue.java
@@ -6,5 +6,11 @@ import lombok.Value;
 @Value
 @Builder
 public class Venue {
-    private String venueTown;
+    private String name;
+    private String addressLine1;
+    private String addressLine2;
+    private String town;
+    private String county;
+    private String postcode;
+    private String googleMapLink;
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/models/serialize/ccd/Venue.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/models/serialize/ccd/Venue.java
@@ -7,10 +7,6 @@ import lombok.Value;
 @Builder
 public class Venue {
     private String name;
-    private String addressLine1;
-    private String addressLine2;
-    private String town;
-    private String county;
-    private String postcode;
+    private Address address;
     private String googleMapLink;
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/TransformJsonCasesToCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/TransformJsonCasesToCaseData.java
@@ -174,13 +174,17 @@ public class TransformJsonCasesToCaseData {
         if (appealCase.getHearing() != null) {
             VenueDetails venueDetails = referenceDataService.getVenueDetails(appealCase.getHearing().getVenueId());
 
-            Venue venue = Venue.builder()
-                .name(venueDetails.getVenName())
-                .addressLine1(venueDetails.getVenAddressLine1())
-                .addressLine2(venueDetails.getVenAddressLine2())
+            Address address = Address.builder()
+                .line1(venueDetails.getVenAddressLine1())
+                .line2(venueDetails.getVenAddressLine2())
                 .town(venueDetails.getVenAddressTown())
                 .county(venueDetails.getVenAddressCounty())
                 .postcode(venueDetails.getVenAddressPostcode())
+                .build();
+
+            Venue venue = Venue.builder()
+                .name(venueDetails.getVenName())
+                .address(address)
                 .googleMapLink(venueDetails.getUrl())
                 .build();
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/CaseDataUtils.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/CaseDataUtils.java
@@ -65,7 +65,13 @@ public final class CaseDataUtils {
             .build();
 
         Venue venue = Venue.builder()
-            .venueTown("Aberdeen")
+            .name("The venue")
+            .addressLine1("12 The Road Avenue")
+            .addressLine2("Village")
+            .town("Aberdeen")
+            .county("Aberdeenshire")
+            .postcode("AB120HN")
+            .googleMapLink("http://www.googlemaps.com/aberdeenvenue")
             .build();
         HearingDetails hearingDetails = HearingDetails.builder()
             .venue(venue)

--- a/src/test/java/uk/gov/hmcts/reform/sscs/CaseDataUtils.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/CaseDataUtils.java
@@ -64,13 +64,17 @@ public final class CaseDataUtils {
             .hearingOptions(hearingOptions)
             .build();
 
-        Venue venue = Venue.builder()
-            .name("The venue")
-            .addressLine1("12 The Road Avenue")
-            .addressLine2("Village")
+        Address venueAddress = Address.builder()
+            .line1("12 The Road Avenue")
+            .line2("Village")
             .town("Aberdeen")
             .county("Aberdeenshire")
-            .postcode("AB120HN")
+            .postcode("AB12 0HN")
+            .build();
+
+        Venue venue = Venue.builder()
+            .name("The venue")
+            .address(venueAddress)
             .googleMapLink("http://www.googlemaps.com/aberdeenvenue")
             .build();
         HearingDetails hearingDetails = HearingDetails.builder()

--- a/src/test/resources/CaseDataArrayWithOptionalFields.json
+++ b/src/test/resources/CaseDataArrayWithOptionalFields.json
@@ -33,11 +33,13 @@
         "value": {
           "venue": {
             "name": "Prudential House",
-            "addressLine1": "36 Dale Street",
-            "addressLine2": "",
-            "town": "Liverpool",
-            "county": "Merseyside",
-            "postcode": "L2 5UZ",
+            "address": {
+              "line1": "36 Dale Street",
+              "line2": "",
+              "town": "Liverpool",
+              "county": "Merseyside",
+              "postcode": "L2 5UZ"
+            },
             "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
           },
           "hearingDate": "2017-05-24",

--- a/src/test/resources/CaseDataArrayWithOptionalFields.json
+++ b/src/test/resources/CaseDataArrayWithOptionalFields.json
@@ -32,7 +32,13 @@
       {
         "value": {
           "venue": {
-            "venueTown": "Aberdeen"
+            "name": "Prudential House",
+            "addressLine1": "36 Dale Street",
+            "addressLine2": "",
+            "town": "Liverpool",
+            "county": "Merseyside",
+            "postcode": "L2 5UZ",
+            "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
           },
           "hearingDate": "2017-05-24",
           "time": "11:00",

--- a/src/test/resources/CaseDataArrayWithUpdates.json
+++ b/src/test/resources/CaseDataArrayWithUpdates.json
@@ -33,11 +33,13 @@
         "value": {
           "venue": {
             "name": "Prudential House",
-            "addressLine1": "36 Dale Street",
-            "addressLine2": "",
-            "town": "Liverpool",
-            "county": "Merseyside",
-            "postcode": "L2 5UZ",
+            "address": {
+              "line1": "36 Dale Street",
+              "line2": "",
+              "town": "Liverpool",
+              "county": "Merseyside",
+              "postcode": "L2 5UZ"
+            },
             "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
           },
           "hearingDate": "2017-05-24",

--- a/src/test/resources/CaseDataArrayWithUpdates.json
+++ b/src/test/resources/CaseDataArrayWithUpdates.json
@@ -32,7 +32,13 @@
       {
         "value": {
           "venue": {
-            "venueTown": "Aberdeen"
+            "name": "Prudential House",
+            "addressLine1": "36 Dale Street",
+            "addressLine2": "",
+            "town": "Liverpool",
+            "county": "Merseyside",
+            "postcode": "L2 5UZ",
+            "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
           },
           "hearingDate": "2017-05-24",
           "time": "11:00",

--- a/src/test/resources/CaseDataContent.json
+++ b/src/test/resources/CaseDataContent.json
@@ -37,7 +37,13 @@
       {
         "value": {
           "venue": {
-            "venueTown": "Aberdeen"
+            "name": "The venue",
+            "addressLine1": "12 The Road Avenue",
+            "addressLine2": "Village",
+            "town": "Aberdeen",
+            "county": "Aberdeenshire",
+            "postcode": "AB120HN",
+            "googleMapLink": "http://www.googlemaps.com/aberdeenvenue"
           },
           "hearingDate": "2017-05-24",
           "time": "10:45",

--- a/src/test/resources/CaseDataContent.json
+++ b/src/test/resources/CaseDataContent.json
@@ -38,11 +38,13 @@
         "value": {
           "venue": {
             "name": "The venue",
-            "addressLine1": "12 The Road Avenue",
-            "addressLine2": "Village",
-            "town": "Aberdeen",
-            "county": "Aberdeenshire",
-            "postcode": "AB120HN",
+            "address": {
+              "line1": "12 The Road Avenue",
+              "line2": "Village",
+              "town": "Aberdeen",
+              "county": "Aberdeenshire",
+              "postcode": "AB12 0HN"
+            },
             "googleMapLink": "http://www.googlemaps.com/aberdeenvenue"
           },
           "hearingDate": "2017-05-24",


### PR DESCRIPTION

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-2814


### Change description ###
- Hearing venue data is now mapped correctly rather than hardecoded to Aberdeen
- Venue address and Google Map URL now added to case data


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```