### PR TITLE
remove codacy coverage integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ cache:
 before_install:
   - curl https://raw.githubusercontent.com/hmcts/reform-api-docs/master/bin/publish-swagger-docs.sh > publish-swagger-docs.sh
   - sudo apt-get install jq
-  - wget -O ./codacy-coverage-reporter-assembly-latest.jar $(curl https://api.github.com/repos/codacy/codacy-coverage-reporter/releases/latest | jq -r .assets[0].browser_download_url)
 
 script:
   - ./gradlew build
@@ -24,5 +23,4 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-  - java -cp ./codacy-coverage-reporter-assembly-latest.jar com.codacy.CodacyCoverageReporter -l Java -r build/reports/jacoco/test/jacocoTestReport.xml
   - test "$TRAVIS_BRANCH" = "master" && test "$TRAVIS_PULL_REQUEST" = "false" && sh ./publish-swagger-docs.sh


### PR DESCRIPTION


### JIRA link (if applicable) ###
No Jira


### Change description ###
Codacy test coverage url is returning null and therefore making builds fail in travis CI. 
I just removed the integration with the codacy test coverage. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
