### PR TITLE
display all health details over unauthenticated http connection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ plugins {
   id 'com.github.ben-manes.versions' version '0.17.0'
   id 'net.ltgt.apt' version '0.14'
   id 'org.sonarqube' version '2.6.2'
+  id "com.gorylenko.gradle-git-properties" version "1.4.21"
 }
 
 group = 'uk.gov.hmcts.reform'

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -19,7 +19,7 @@ variable "infrastructure_env" {
 
 variable "management_security_enabled" {
   type    = "string"
-  default = "true"
+  default = "false"
 }
 
 variable "subscription" {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,7 +22,12 @@ idam:
       secret: ${IDAM_OAUTH2_CLIENT_SECRET:QM5RQQ53LZFOSIXJ}
     redirectUrl: ${IDAM_SSCS_URL:https://localhost:9000/poc}
 
-management.security.enabled: ${MANAGEMENT_SECURITY_ENABLED:false}
+management:
+  security.enabled: ${MANAGEMENT_SECURITY_ENABLED:false}
+  info.git.mode: full
+  endpoints:
+    health.show-details: always
+
 
 sftp:
   keyLocation:  |


### PR DESCRIPTION
### JIRA link (if applicable) ###

No jira

### Change description ###
by default, only the health status is exposed over an unauthenticated HTTP connection. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
