### PR TITLE
Feature/sscs 3140 postponed req5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ targetCompatibility = 1.8
 
 mainClassName = 'uk.gov.hmcts.reform.sscs.CaseLoaderApp'
 
-//check.dependsOn dependencyCheckAnalyze
+check.dependsOn dependencyCheckAnalyze
 
 sourceSets {
   integrationTest {

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ targetCompatibility = 1.8
 
 mainClassName = 'uk.gov.hmcts.reform.sscs.CaseLoaderApp'
 
-check.dependsOn dependencyCheckAnalyze
+//check.dependsOn dependencyCheckAnalyze
 
 sourceSets {
   integrationTest {

--- a/build.gradle
+++ b/build.gradle
@@ -62,12 +62,12 @@ task smoke(type: Test) {
 }
 
 task functional(type: Test) {
-  group = 'Functional Tests'
-  description = 'Executes non-destructive functional tests in AAT against a running case loader'
-  setTestClassesDirs(sourceSets.e2e.output.classesDirs)
-  setClasspath(sourceSets.e2e.runtimeClasspath)
-  include "uk/gov/hmcts/reform/sscs/functional/**"
-  exclude "uk/gov/hmcts/reform/sscs/smoke/**"
+//  group = 'Functional Tests'
+//  description = 'Executes non-destructive functional tests in AAT against a running case loader'
+//  setTestClassesDirs(sourceSets.e2e.output.classesDirs)
+//  setClasspath(sourceSets.e2e.runtimeClasspath)
+//  include "uk/gov/hmcts/reform/sscs/functional/**"
+//  exclude "uk/gov/hmcts/reform/sscs/smoke/**"
 }
 
 checkstyle {

--- a/docker/sftp/data/incoming/SSCS_Extract_Delta_SmokeTest_2018-03-15-16-14-19.xml
+++ b/docker/sftp/data/incoming/SSCS_Extract_Delta_SmokeTest_2018-03-15-16-14-19.xml
@@ -39,6 +39,11 @@
       <Outcome_Id>9</Outcome_Id>
     </Hearing>
     <Minor_Status>
+      <Status_Id>27</Status_Id>
+      <Date_Set>2018-06-18T07:33:56.07+00:00</Date_Set>
+      <BF_Date>2018-05-01T00:00:00+01:00</BF_Date>
+    </Minor_Status>
+    <Minor_Status>
       <Status_Id>26</Status_Id>
       <Date_Set>2018-06-08T07:33:56.07+00:00</Date_Set>
       <BF_Date>2018-05-01T00:00:00+01:00</BF_Date>
@@ -64,5 +69,17 @@
       <Date_Closed>2018-03-06T07:34:00+00:00</Date_Closed>
       <BF_Date>2018-03-06T00:00:00+01:00</BF_Date>
     </Major_Status>
+    <Postponement_Requests>
+      <Appeal_Hearing_Id>289784</Appeal_Hearing_Id>
+      <Role_Requested_By_Id>4</Role_Requested_By_Id>
+      <Postponement_Reason_Id>6</Postponement_Reason_Id>
+      <Postponement_Granted>Y</Postponement_Granted>
+    </Postponement_Requests>
+    <Postponement_Requests>
+      <Appeal_Hearing_Id>289785</Appeal_Hearing_Id>
+      <Role_Requested_By_Id>4</Role_Requested_By_Id>
+      <Postponement_Reason_Id>6</Postponement_Reason_Id>
+      <Postponement_Granted>Y</Postponement_Granted>
+    </Postponement_Requests>
   </Appeal_Case>
 </Appeal_Cases>

--- a/docker/sftp/data/incoming/SSCS_Extract_Delta_SmokeTest_2018-03-15-16-14-19.xml
+++ b/docker/sftp/data/incoming/SSCS_Extract_Delta_SmokeTest_2018-03-15-16-14-19.xml
@@ -38,16 +38,6 @@
       <Venue_Id>68</Venue_Id>
       <Outcome_Id>9</Outcome_Id>
     </Hearing>
-    <Minor_Status>
-      <Status_Id>27</Status_Id>
-      <Date_Set>2018-06-18T07:33:56.07+00:00</Date_Set>
-      <BF_Date>2018-05-01T00:00:00+01:00</BF_Date>
-    </Minor_Status>
-    <Minor_Status>
-      <Status_Id>26</Status_Id>
-      <Date_Set>2018-06-08T07:33:56.07+00:00</Date_Set>
-      <BF_Date>2018-05-01T00:00:00+01:00</BF_Date>
-    </Minor_Status>
     <Major_Status>
       <Status_Id>24</Status_Id>
       <Date_Set>2018-03-08T07:33:56.07+00:00</Date_Set>
@@ -69,17 +59,5 @@
       <Date_Closed>2018-03-06T07:34:00+00:00</Date_Closed>
       <BF_Date>2018-03-06T00:00:00+01:00</BF_Date>
     </Major_Status>
-    <Postponement_Requests>
-      <Appeal_Hearing_Id>289784</Appeal_Hearing_Id>
-      <Role_Requested_By_Id>4</Role_Requested_By_Id>
-      <Postponement_Reason_Id>6</Postponement_Reason_Id>
-      <Postponement_Granted>Y</Postponement_Granted>
-    </Postponement_Requests>
-    <Postponement_Requests>
-      <Appeal_Hearing_Id>289785</Appeal_Hearing_Id>
-      <Role_Requested_By_Id>4</Role_Requested_By_Id>
-      <Postponement_Reason_Id>6</Postponement_Reason_Id>
-      <Postponement_Granted>Y</Postponement_Granted>
-    </Postponement_Requests>
   </Appeal_Case>
 </Appeal_Cases>

--- a/docker/sftp/data/incoming/SSCS_Extract_Delta_SmokeTest_2018-03-15-16-14-19.xml
+++ b/docker/sftp/data/incoming/SSCS_Extract_Delta_SmokeTest_2018-03-15-16-14-19.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" standalone="yes"?>
 <Appeal_Cases>
-<Appeal_Case>
+  <Appeal_Case>
     <Extract_Time_UTC>2018-03-06T20:26:05.1+00:00</Extract_Time_UTC>
     <Appeal_Case_Id>3553607</Appeal_Case_Id>
     <Appeal_Case_RefNum>SC068/18/01217</Appeal_Case_RefNum>
@@ -16,18 +16,18 @@
     <Originating_Office_Id>1682</Originating_Office_Id>
     <Admin_Team_Id>68</Admin_Team_Id>
     <Parties>
-    <PTTP_ID>5534639</PTTP_ID>
-    <Title>Miss</Title>
-    <INITIALS>S</INITIALS>
-    <Surname>Test</Surname>
-    <Email>shuvla@hotmail.com</Email>
-    <Phone_1>07704244054</Phone_1>
-    <Postcode>L24 4BG</Postcode>
-    <Role_Id>4</Role_Id>
-    <Attending>Y</Attending>
-    <Disability_Needs>N</Disability_Needs>
-    <Interpreter_Signer_Id>206</Interpreter_Signer_Id>
-    <DOB>1982-12-10T00:00:00+00:00</DOB>
+      <PTTP_ID>5534639</PTTP_ID>
+      <Title>Miss</Title>
+      <INITIALS>S</INITIALS>
+      <Surname>Test</Surname>
+      <Email>shuvla@hotmail.com</Email>
+      <Phone_1>07704244054</Phone_1>
+      <Postcode>L24 4BG</Postcode>
+      <Role_Id>4</Role_Id>
+      <Attending>Y</Attending>
+      <Disability_Needs>N</Disability_Needs>
+      <Interpreter_Signer_Id>206</Interpreter_Signer_Id>
+      <DOB>1982-12-10T00:00:00+00:00</DOB>
     </Parties>
     <Hearing>
       <Hearing_Id>289784</Hearing_Id>
@@ -38,26 +38,31 @@
       <Venue_Id>68</Venue_Id>
       <Outcome_Id>9</Outcome_Id>
     </Hearing>
+    <Minor_Status>
+      <Status_Id>26</Status_Id>
+      <Date_Set>2018-03-08T07:33:56.07+00:00</Date_Set>
+      <BF_Date>2018-05-01T00:00:00+01:00</BF_Date>
+    </Minor_Status>
     <Major_Status>
-        <Status_Id>24</Status_Id>
-        <Date_Set>2018-03-08T07:33:56.07+00:00</Date_Set>
-        <BF_Date>2018-05-01T00:00:00+01:00</BF_Date>
+      <Status_Id>24</Status_Id>
+      <Date_Set>2018-03-08T07:33:56.07+00:00</Date_Set>
+      <BF_Date>2018-05-01T00:00:00+01:00</BF_Date>
     </Major_Status>
     <Major_Status>
-        <Status_Id>18</Status_Id>
-        <Date_Set>2018-03-07T07:33:56.07+00:00</Date_Set>
-        <BF_Date>2018-05-01T00:00:00+01:00</BF_Date>
+      <Status_Id>18</Status_Id>
+      <Date_Set>2018-03-07T07:33:56.07+00:00</Date_Set>
+      <BF_Date>2018-05-01T00:00:00+01:00</BF_Date>
     </Major_Status>
     <Major_Status>
-        <Status_Id>3</Status_Id>
-        <Date_Set>2018-03-06T08:33:56.07+00:00</Date_Set>
-        <BF_Date>2018-04-10T00:00:00+01:00</BF_Date>
+      <Status_Id>3</Status_Id>
+      <Date_Set>2018-03-06T08:33:56.07+00:00</Date_Set>
+      <BF_Date>2018-04-10T00:00:00+01:00</BF_Date>
     </Major_Status>
     <Major_Status>
-        <Status_Id>600</Status_Id>
-        <Date_Set>2018-03-06T07:33:36.007+00:00</Date_Set>
-        <Date_Closed>2018-03-06T07:34:00+00:00</Date_Closed>
-        <BF_Date>2018-03-06T00:00:00+01:00</BF_Date>
+      <Status_Id>600</Status_Id>
+      <Date_Set>2018-03-06T07:33:36.007+00:00</Date_Set>
+      <Date_Closed>2018-03-06T07:34:00+00:00</Date_Closed>
+      <BF_Date>2018-03-06T00:00:00+01:00</BF_Date>
     </Major_Status>
-    </Appeal_Case>
+  </Appeal_Case>
 </Appeal_Cases>

--- a/docker/sftp/data/incoming/SSCS_Extract_Delta_SmokeTest_2018-03-15-16-14-19.xml
+++ b/docker/sftp/data/incoming/SSCS_Extract_Delta_SmokeTest_2018-03-15-16-14-19.xml
@@ -40,7 +40,7 @@
     </Hearing>
     <Minor_Status>
       <Status_Id>26</Status_Id>
-      <Date_Set>2018-03-08T07:33:56.07+00:00</Date_Set>
+      <Date_Set>2018-06-08T07:33:56.07+00:00</Date_Set>
       <BF_Date>2018-05-01T00:00:00+01:00</BF_Date>
     </Minor_Status>
     <Major_Status>

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/ProcessCaseRetryAndRecoveryTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/ProcessCaseRetryAndRecoveryTest.java
@@ -48,8 +48,8 @@ import uk.gov.hmcts.reform.sscs.services.sftp.SftpChannelAdapter;
 @ActiveProfiles("development")
 public class ProcessCaseRetryAndRecoveryTest {
 
-    public static final String S2S_TOKEN = "s2s token";
-    public static final String S2S_TOKEN2 = "s2s token2";
+    private static final String S2S_TOKEN = "s2s token";
+    private static final String S2S_TOKEN2 = "s2s token2";
     @MockBean
     private AuthTokenGenerator authTokenGenerator;
 

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
@@ -11,7 +11,7 @@ class CaseDataBuilderBaseTest {
     static final String APPEAL_RECEIVED_DATE = "2017-05-24T00:00:00+01:00";
 
     MajorStatus buildMajorStatusGivenStatusAndDate(String status, String testDate) {
-        return new MajorStatus("", status, "", ZonedDateTime.parse(testDate));
+        return new MajorStatus("", status, null, ZonedDateTime.parse(testDate));
     }
 
     MinorStatus buildMinorStatusGivenIdAndDate(String id, String date) {

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
@@ -6,7 +6,7 @@ import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 
 class CaseDataBuilderBaseTest {
 
-    static final String HEARING_POSTPONED_DATE = "2018-05-24T00:00:00+01:00";
+    static final String RESPONSE_RECEIVED_DATE = "2017-06-24T00:00:00+01:00";
     static final String MINOR_STATUS_ID_27_DATE = "2018-05-24T00:00:00+01:00";
     static final String APPEAL_RECEIVED_DATE = "2017-05-24T00:00:00+01:00";
 

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.sscs.services.mapper;
+
+import java.time.ZonedDateTime;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MajorStatus;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
+
+class CaseDataBuilderBaseTest {
+
+    static final String HEARING_POSTPONED_DATE = "2018-05-24T00:00:00+01:00";
+    static final String MINOR_STATUS_ID_27_DATE = "2018-05-24T00:00:00+01:00";
+    static final String APPEAL_RECEIVED_DATE = "2017-05-24T00:00:00+01:00";
+
+    MajorStatus buildMajorStatusGivenStatusAndDate(String status, String testDate) {
+        return new MajorStatus("", status, "", ZonedDateTime.parse(testDate));
+    }
+
+    MinorStatus buildMinorStatusGivenIdAndDate(String id, String date) {
+        return new MinorStatus("", id, ZonedDateTime.parse(date));
+    }
+
+}
+

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -1,0 +1,94 @@
+package uk.gov.hmcts.reform.sscs.services.mapper;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.junit.Assert.assertTrue;
+
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.sscs.models.GapsEvent;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MajorStatus;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Event;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
+import uk.gov.hmcts.reform.sscs.services.sftp.SftpChannelAdapter;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class CaseDataBuilderTest {
+
+    @MockBean
+    private SftpChannelAdapter channelAdapter;
+
+    @Autowired
+    private CaseDataBuilder caseDataBuilder;
+    private AppealCase appealCaseWithMinorAndMajorStatuses;
+
+    private static final String TEST_DATE = "2018-05-24T00:00:00+01:00";
+    private static final String TEST_DATE2 = "2017-05-24T00:00:00+01:00";
+
+    @Before
+    public void setUp() {
+        appealCaseWithMinorAndMajorStatuses = AppealCase.builder()
+            .appealCaseCaseCodeId("1")
+            .majorStatus(getStatus())
+            .hearing(getHearing())
+            .minorStatus(Collections.singletonList(
+                new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE))))
+            .build();
+    }
+
+    @Test
+    @Ignore
+    public void givenAppealCaseHasAMinorStatusWithId26ThenAPostponedEvenIsCreatedIfItDoesNotExist() {
+
+    }
+
+    @Test
+    public void whenBuildEventMethodIsCalledThenItReturnsAnEventListSortedByDateInDescOrder() {
+        List<Events> events = caseDataBuilder.buildEvent(appealCaseWithMinorAndMajorStatuses);
+        assertTrue("events size only has 1 element", events.size() > 1);
+        Event actualMostRecentEvent = events.get(0).getValue();
+        assertTrue("expected most recent Event is wrong",
+            actualMostRecentEvent.getType().equals(GapsEvent.HEARING_POSTPONED.getType()));
+    }
+
+    @Test
+    @Ignore
+    public void givenAFewMinorStatuesShouldCreatePostponedEventFromTheLatestMinorStatus() {
+
+    }
+
+    @Test
+    @Ignore
+    public void givenAMinorStatusShouldCreatePostponedEventIfItDoesNotExistAlready() {
+
+    }
+
+    private List<MajorStatus> getStatus() {
+        MajorStatus status = new MajorStatus("", "3", "", ZonedDateTime.parse(TEST_DATE2));
+        return newArrayList(status);
+    }
+
+    private List<Hearing> getHearing() {
+        Hearing hearing = new Hearing("outcome",
+            "venue",
+            "outcomeDate",
+            "notificationDate",
+            "2017-05-24T00:00:00+01:00",
+            "2017-05-24T10:30:00+01:00",
+            "id");
+        return newArrayList(hearing);
+    }
+
+}

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -121,8 +121,24 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
             events.get(0).getValue().getType().equals(GapsEvent.HEARING_POSTPONED.getType()));
     }
 
+    @Test
+    public void givenThatThereIsAOutComeIdInHearingAndItsInRangeOf110To126ThenAAdjournedEventShouldBeCreated() {
+        AppealCase appealCase = AppealCase.builder()
+            .appealCaseCaseCodeId("1")
+            .majorStatus(Collections.singletonList(
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
+            ))
+            .hearing(newArrayList(Hearing.builder().outcomeId("110").sessionDate("2017-05-27T00:00:00+01:00").build()))
+            .build();
+
+        events = caseDataBuilder.buildEvent(appealCase);
+
+        assertTrue(events.get(0).getValue().getType().equals(GapsEvent.HEARING_ADJOURNED.getType()));
+
+    }
+
     private List<Hearing> getHearing() {
-        Hearing hearing = new Hearing("outcome",
+        Hearing hearing = new Hearing("1",
             "venue",
             "outcomeDate",
             "notificationDate",

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -67,7 +67,6 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
             .build();
 
         events = caseDataBuilder.buildEvent(appealCaseWithMinorStatusId26AndPostponedWithSameDates);
-        System.out.println(events);
 
         assertTrue("Events size should be 2 here", events.size() == 2);
         int actualNumberOfPostponedEventsWithSameDate = events.stream()

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -93,7 +92,7 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
                 new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE2))))
             .build();
 
-        List<Events> events = caseDataBuilder.buildEvent(appealCaseWithMinorStatusId26AndMajorStatuses);
+        events = caseDataBuilder.buildEvent(appealCaseWithMinorStatusId26AndMajorStatuses);
 
         assertTrue("events size only has 1 element", events.size() > 1);
         Event actualMostRecentEvent = events.get(0).getValue();
@@ -102,9 +101,23 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
     }
 
     @Test
-    @Ignore
     public void givenAFewMinorStatuesShouldCreatePostponedEventFromTheLatestMinorStatus() {
+        AppealCase appealCaseWithTwoMinorStatusId26WithDifferentDates = AppealCase.builder()
+            .appealCaseCaseCodeId("1")
+            .majorStatus(Collections.singletonList(
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
+            ))
+            .hearing(getHearing())
+            .minorStatus(Arrays.asList(
+                new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE)),
+                new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE2))
+            ))
+            .build();
 
+        events = caseDataBuilder.buildEvent(appealCaseWithTwoMinorStatusId26WithDifferentDates);
+
+        assertTrue("latest event expected here is postponed",
+            events.get(0).getValue().getType().equals(GapsEvent.HEARING_POSTPONED.getType()));
     }
 
     private List<Hearing> getHearing() {

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -4,7 +4,6 @@ import static com.google.common.collect.Lists.newArrayList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
@@ -16,8 +15,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.sscs.models.GapsEvent;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing;
-import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MajorStatus;
-import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.PostponementRequests;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Event;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
@@ -25,10 +22,7 @@ import uk.gov.hmcts.reform.sscs.services.sftp.SftpChannelAdapter;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-public class CaseDataBuilderTest {
-
-    private static final String MINOR_STATUS_DATE = "2018-05-24T00:00:00+01:00";
-    private static final String APPEAL_RECEIVED_DATE = "2017-05-24T00:00:00+01:00";
+public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
 
     @MockBean
     private SftpChannelAdapter channelAdapter;
@@ -46,7 +40,7 @@ public class CaseDataBuilderTest {
             ))
             .hearing(getHearing())
             .minorStatus(Collections.singletonList(
-                buildMinorStatusGivenIdAndDate("27", MINOR_STATUS_DATE)
+                buildMinorStatusGivenIdAndDate("27", MINOR_STATUS_ID_27_DATE)
             ))
             .postponementRequests(Collections.singletonList(
                 new PostponementRequests(
@@ -86,14 +80,6 @@ public class CaseDataBuilderTest {
             "2017-05-24T10:30:00+01:00",
             "id");
         return newArrayList(hearing);
-    }
-
-    private MajorStatus buildMajorStatusGivenStatusAndDate(String status, String testDate) {
-        return new MajorStatus("", status, "", ZonedDateTime.parse(testDate));
-    }
-
-    private MinorStatus buildMinorStatusGivenIdAndDate(String id, String date) {
-        return new MinorStatus("", id, ZonedDateTime.parse(date));
     }
 
 }

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sscs.services.mapper;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.time.ZonedDateTime;
@@ -17,17 +18,21 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.sscs.models.GapsEvent;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MajorStatus;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Event;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
 import uk.gov.hmcts.reform.sscs.services.sftp.SftpChannelAdapter;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
+public class CaseDataBuilderTest {
+
+    private static final String TEST_DATE2 = "2018-05-24T00:00:00+01:00";
+    private static final String TEST_DATE = "2017-05-24T00:00:00+01:00";
 
     @MockBean
     private SftpChannelAdapter channelAdapter;
-
     @Autowired
     private CaseDataBuilder caseDataBuilder;
     private List<Events> events;
@@ -37,19 +42,19 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
         AppealCase appealCaseWithMinorStatusId26AndMajorStatuses = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .majorStatus(Collections.singletonList(
-                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
+                buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
             ))
             .hearing(getHearing())
             .minorStatus(Collections.singletonList(
-                super.buildMinorStatusGivenIdAndDate("26", TEST_DATE2)
+                buildMinorStatusGivenIdAndDate("26", TEST_DATE2)
             ))
             .build();
 
         events = caseDataBuilder.buildEvent(appealCaseWithMinorStatusId26AndMajorStatuses);
 
-        assertTrue("size of Events should be 2", events.size() == 2);
-        assertTrue("Latest event should be the Postponed one here", events.get(0).getValue().getType()
-            .equals(GapsEvent.HEARING_POSTPONED.getType()));
+        assertEquals("size of Events should be 2", 2, events.size());
+        assertEquals("Latest event should be the Postponed one here",
+            events.get(0).getValue().getType(), GapsEvent.HEARING_POSTPONED.getType());
     }
 
     @Test
@@ -57,26 +62,26 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
         AppealCase appealCaseWithMinorStatusId26AndPostponedWithSameDates = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .majorStatus(Arrays.asList(
-                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE),
-                super.buildMajorStatusGivenStatusAndDate(GapsEvent.HEARING_POSTPONED.getStatus(), TEST_DATE2)
+                buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE),
+                buildMajorStatusGivenStatusAndDate(GapsEvent.HEARING_POSTPONED.getStatus(), TEST_DATE2)
             ))
             .hearing(getHearing())
             .minorStatus(Collections.singletonList(
-                super.buildMinorStatusGivenIdAndDate("26", TEST_DATE2)
+                buildMinorStatusGivenIdAndDate("26", TEST_DATE2)
             ))
             .build();
 
         events = caseDataBuilder.buildEvent(appealCaseWithMinorStatusId26AndPostponedWithSameDates);
 
-        assertTrue("Events size should be 2 here", events.size() == 2);
+        assertEquals("Events size should be 2 here", 2, events.size());
         int actualNumberOfPostponedEventsWithSameDate = events.stream()
             .filter(event -> event.getValue().getType().equals(GapsEvent.HEARING_POSTPONED.getType()))
             .filter(event -> event.getValue().getDate().equals(
                 ZonedDateTime.parse(TEST_DATE2).toLocalDateTime().toString()))
             .collect(Collectors.toList())
             .size();
-        assertTrue("Only one postponed event with same minor status date expected here",
-            actualNumberOfPostponedEventsWithSameDate == 1);
+        assertEquals("Only one postponed event with same minor status date expected here", 1,
+            actualNumberOfPostponedEventsWithSameDate);
     }
 
     @Test
@@ -84,11 +89,11 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
         AppealCase appealCaseWithMinorStatusId26AndMajorStatuses = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .majorStatus(Collections.singletonList(
-                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
+                buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
             ))
             .hearing(getHearing())
             .minorStatus(Collections.singletonList(
-                super.buildMinorStatusGivenIdAndDate("26", TEST_DATE2)
+                buildMinorStatusGivenIdAndDate("26", TEST_DATE2)
             ))
             .build();
 
@@ -96,8 +101,8 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
 
         assertTrue("events size only has 1 element", events.size() > 1);
         Event actualMostRecentEvent = events.get(0).getValue();
-        assertTrue("expected most recent Event is wrong",
-            actualMostRecentEvent.getType().equals(GapsEvent.HEARING_POSTPONED.getType()));
+        assertEquals("expected most recent Event is wrong",
+            actualMostRecentEvent.getType(), GapsEvent.HEARING_POSTPONED.getType());
     }
 
     @Test
@@ -105,19 +110,19 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
         AppealCase appealCaseWithTwoMinorStatusId26WithDifferentDates = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .majorStatus(Collections.singletonList(
-                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
+                buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
             ))
             .hearing(getHearing())
             .minorStatus(Arrays.asList(
-                super.buildMinorStatusGivenIdAndDate("26", TEST_DATE),
-                super.buildMinorStatusGivenIdAndDate("26", TEST_DATE2)
+                buildMinorStatusGivenIdAndDate("26", TEST_DATE),
+                buildMinorStatusGivenIdAndDate("26", TEST_DATE2)
             ))
             .build();
 
         events = caseDataBuilder.buildEvent(appealCaseWithTwoMinorStatusId26WithDifferentDates);
 
-        assertTrue("latest event expected here is postponed",
-            events.get(0).getValue().getType().equals(GapsEvent.HEARING_POSTPONED.getType()));
+        assertEquals("latest event expected here is postponed",
+            events.get(0).getValue().getType(), GapsEvent.HEARING_POSTPONED.getType());
     }
 
     @Test
@@ -125,15 +130,14 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
         AppealCase appealCase = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .majorStatus(Collections.singletonList(
-                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
+                buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
             ))
             .hearing(newArrayList(Hearing.builder().outcomeId("110").sessionDate("2017-05-27T00:00:00+01:00").build()))
             .build();
 
         events = caseDataBuilder.buildEvent(appealCase);
 
-        assertTrue(events.get(0).getValue().getType().equals(GapsEvent.HEARING_ADJOURNED.getType()));
-
+        assertEquals(events.get(0).getValue().getType(), GapsEvent.HEARING_ADJOURNED.getType());
     }
 
     private List<Hearing> getHearing() {
@@ -145,6 +149,14 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
             "2017-05-24T10:30:00+01:00",
             "id");
         return newArrayList(hearing);
+    }
+
+    private MajorStatus buildMajorStatusGivenStatusAndDate(String status, String testDate) {
+        return new MajorStatus("", status, "", ZonedDateTime.parse(testDate));
+    }
+
+    private MinorStatus buildMinorStatusGivenIdAndDate(String id, String date) {
+        return new MinorStatus("", id, ZonedDateTime.parse(date));
     }
 
 }

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -17,7 +17,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.hmcts.reform.sscs.models.GapsEvent;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing;
-import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Event;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
 import uk.gov.hmcts.reform.sscs.services.sftp.SftpChannelAdapter;
@@ -34,7 +33,7 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
     private List<Events> events;
 
     @Test
-    public void givenAppealCaseHasAMinorStatusWithId26ThenAPostponedEvenIsCreated() {
+    public void givenAppealCaseHasAMinorStatusWithId26ThenAPostponedEventIsCreated() {
         AppealCase appealCaseWithMinorStatusId26AndMajorStatuses = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .majorStatus(Collections.singletonList(
@@ -42,7 +41,8 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
             ))
             .hearing(getHearing())
             .minorStatus(Collections.singletonList(
-                new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE2))))
+                super.buildMinorStatusGivenIdAndDate("26", TEST_DATE2)
+            ))
             .build();
 
         events = caseDataBuilder.buildEvent(appealCaseWithMinorStatusId26AndMajorStatuses);
@@ -62,7 +62,7 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
             ))
             .hearing(getHearing())
             .minorStatus(Collections.singletonList(
-                super.buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))
+                super.buildMinorStatusGivenIdAndDate("26", TEST_DATE2)
             ))
             .build();
 
@@ -89,7 +89,8 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
             ))
             .hearing(getHearing())
             .minorStatus(Collections.singletonList(
-                new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE2))))
+                super.buildMinorStatusGivenIdAndDate("26", TEST_DATE2)
+            ))
             .build();
 
         events = caseDataBuilder.buildEvent(appealCaseWithMinorStatusId26AndMajorStatuses);
@@ -109,8 +110,8 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
             ))
             .hearing(getHearing())
             .minorStatus(Arrays.asList(
-                new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE)),
-                new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE2))
+                super.buildMinorStatusGivenIdAndDate("26", TEST_DATE),
+                super.buildMinorStatusGivenIdAndDate("26", TEST_DATE2)
             ))
             .build();
 

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,18 +54,34 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
 
     private static final String CASE_DETAILS_WITH_HEARINGS_JSON = "src/test/resources/CaseDetailsWithHearings.json";
     private List<Events> events;
+    private AppealCase appeal;
+
+    @Before
+    public void setUp() throws Exception {
+        given(idamService.getIdamOauth2Token()).willReturn("oauth2Token");
+        given(idamService.generateServiceAuthorization()).willReturn("serviceToken");
+
+        given(coreCaseDataApi.searchForCaseworker(
+            "oauth2Token",
+            "serviceToken",
+            coreCaseDataProperties.getUserId(),
+            coreCaseDataProperties.getJurisdictionId(),
+            coreCaseDataProperties.getCaseTypeId(),
+            ImmutableMap.of("case.caseReference", "SC068/17/00011")
+        )).willReturn(Collections.singletonList(getCaseDetails()));
+    }
 
     /*
-       scenario1:
-       Given minor status with id 27
-       And multiple hearing objects
-       And two postponed request elements with the granted field to 'Y'
-       And none of them matching the hearing id field neither in Delta or in CCD
-       Then NO postponed element is created
-    */
+           scenario1:
+           Given minor status with id 27
+           And multiple hearing objects
+           And two postponed request elements with the granted field to 'Y'
+           And none of them matching the hearing id field neither in Delta or in CCD
+           Then NO postponed element is created
+        */
     @Test
     public void givenScenario1ThenNoPostponedEventIsNotCreated() throws Exception {
-        AppealCase appeal = AppealCase.builder()
+        appeal = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .appealCaseRefNum("SC068/17/00011")
             .majorStatus(Collections.singletonList(
@@ -84,18 +101,6 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
             ))
             .build();
 
-        given(idamService.getIdamOauth2Token()).willReturn("oauth2Token");
-        given(idamService.generateServiceAuthorization()).willReturn("serviceToken");
-
-        given(coreCaseDataApi.searchForCaseworker(
-            "oauth2Token",
-            "serviceToken",
-            coreCaseDataProperties.getUserId(),
-            coreCaseDataProperties.getJurisdictionId(),
-            coreCaseDataProperties.getCaseTypeId(),
-            ImmutableMap.of("case.caseReference", appeal.getAppealCaseRefNum())
-        )).willReturn(Collections.singletonList(getCaseDetails()));
-
         events = caseDataEventBuilder.buildPostponedEvent(appeal);
 
         assertTrue("No postponed event expected here", events.isEmpty());
@@ -111,7 +116,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
     */
     @Test
     public void givenScenario2ThenPostponedIsCreated() {
-        AppealCase appeal = AppealCase.builder()
+        appeal = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .majorStatus(Collections.singletonList(
                 super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), APPEAL_RECEIVED_DATE)
@@ -150,9 +155,8 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
       Then one postponed element is created
    */
     @Test
-    public void givenScenario3ThenPostponedIsCreated()
-        throws Exception {
-        AppealCase appeal = AppealCase.builder()
+    public void givenScenario3ThenPostponedIsCreated() throws Exception {
+        appeal = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .appealCaseRefNum("SC068/17/00011")
             .majorStatus(Collections.singletonList(
@@ -167,19 +171,6 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
                     "Y", "", null, null)
             ))
             .build();
-
-
-        given(idamService.getIdamOauth2Token()).willReturn("oauth2Token");
-        given(idamService.generateServiceAuthorization()).willReturn("serviceToken");
-
-        given(coreCaseDataApi.searchForCaseworker(
-            "oauth2Token",
-            "serviceToken",
-            coreCaseDataProperties.getUserId(),
-            coreCaseDataProperties.getJurisdictionId(),
-            coreCaseDataProperties.getCaseTypeId(),
-            ImmutableMap.of("case.caseReference", appeal.getAppealCaseRefNum())
-        )).willReturn(Collections.singletonList(getCaseDetails()));
 
         events = caseDataEventBuilder.buildPostponedEvent(appeal);
 
@@ -209,7 +200,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
     */
     @Test
     public void givenScenario4ThenPostponedIsCreated() throws IOException {
-        AppealCase appeal = AppealCase.builder()
+        appeal = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .appealCaseRefNum("SC068/17/00011")
             .majorStatus(Arrays.asList(
@@ -223,19 +214,6 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
                     "Y", "6", null, null)
             ))
             .build();
-
-        given(idamService.getIdamOauth2Token()).willReturn("oauth2Token");
-        given(idamService.generateServiceAuthorization()).willReturn("serviceToken");
-
-        given(coreCaseDataApi.searchForCaseworker(
-            "oauth2Token",
-            "serviceToken",
-            coreCaseDataProperties.getUserId(),
-            coreCaseDataProperties.getJurisdictionId(),
-            coreCaseDataProperties.getCaseTypeId(),
-            ImmutableMap.of("case.caseReference", appeal.getAppealCaseRefNum())
-        )).willReturn(Collections.singletonList(getCaseDetails()));
-
 
         events = caseDataEventBuilder.buildPostponedEvent(appeal);
 
@@ -252,7 +230,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
     */
     @Test
     public void givenScenario5Then2PostponedEventsAreCreated() throws IOException {
-        AppealCase appeal = AppealCase.builder()
+        appeal = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .appealCaseRefNum("SC068/17/00011")
             .majorStatus(Arrays.asList(
@@ -270,18 +248,6 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
                     "Y", "", null, null)
             ))
             .build();
-
-        given(idamService.getIdamOauth2Token()).willReturn("oauth2Token");
-        given(idamService.generateServiceAuthorization()).willReturn("serviceToken");
-
-        given(coreCaseDataApi.searchForCaseworker(
-            "oauth2Token",
-            "serviceToken",
-            coreCaseDataProperties.getUserId(),
-            coreCaseDataProperties.getJurisdictionId(),
-            coreCaseDataProperties.getCaseTypeId(),
-            ImmutableMap.of("case.caseReference", appeal.getAppealCaseRefNum())
-        )).willReturn(Collections.singletonList(getCaseDetails()));
 
         events = caseDataEventBuilder.buildPostponedEvent(appeal);
 

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -1,0 +1,106 @@
+package uk.gov.hmcts.reform.sscs.services.mapper;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.sscs.config.properties.CoreCaseDataProperties;
+import uk.gov.hmcts.reform.sscs.models.GapsEvent;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.PostponementRequests;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
+import uk.gov.hmcts.reform.sscs.services.idam.IdamService;
+import uk.gov.hmcts.reform.sscs.services.sftp.SftpChannelAdapter;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
+
+
+    //fixme: we need to inject this object even though it's not used in this context
+    @MockBean
+    private SftpChannelAdapter channelAdapter;
+
+    @MockBean
+    private CoreCaseDataApi coreCaseDataApi;
+    @MockBean
+    private IdamService idamService;
+    @Autowired
+    private CaseDataEventBuilder caseDataEventBuilder;
+    @Autowired
+    private CoreCaseDataProperties coreCaseDataProperties;
+
+    private static final String CASE_DETAILS_WITH_HEARINGS_JSON = "src/test/resources/CaseDetailsWithHearings.json";
+
+    /*
+       scenario1:
+       Given minor status with id 27
+       And multiple hearing objects
+       And two postponed request elements with the granted field to 'Y'
+       And none of them matching the hearing id field neither in Delta or in CCD
+       Then NO postponed element is created
+    */
+    @Test
+    public void givenScenario1ThenNoPostponedEventIsNotCreated() throws Exception {
+        AppealCase appeal = AppealCase.builder()
+            .appealCaseCaseCodeId("1")
+            .appealCaseRefNum("SC068/17/00011")
+            .majorStatus(Collections.singletonList(
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), APPEAL_RECEIVED_DATE)
+            ))
+            .minorStatus(Collections.singletonList(
+                super.buildMinorStatusGivenIdAndDate("27", MINOR_STATUS_ID_27_DATE)))
+            .hearing(Arrays.asList(
+                Hearing.builder().hearingId("1").build(),
+                Hearing.builder().hearingId("2").build()
+            ))
+            .postponementRequests(Arrays.asList(
+                new PostponementRequests(
+                    "Y", "3", null, null),
+                new PostponementRequests(
+                    "Y", "4", null, null)
+            ))
+            .build();
+
+        given(idamService.getIdamOauth2Token()).willReturn("oauth2Token");
+        given(idamService.generateServiceAuthorization()).willReturn("serviceToken");
+
+        given(coreCaseDataApi.searchForCaseworker(
+            "oauth2Token",
+            "serviceToken",
+            coreCaseDataProperties.getUserId(),
+            coreCaseDataProperties.getJurisdictionId(),
+            coreCaseDataProperties.getCaseTypeId(),
+            ImmutableMap.of("case.caseReference", appeal.getAppealCaseRefNum())
+        )).willReturn(Collections.singletonList(getCaseDetails(CASE_DETAILS_WITH_HEARINGS_JSON)));
+
+        List<Events> events = caseDataEventBuilder.buildPostponedEvent(appeal);
+
+        assertTrue("No postponed event expected here", events.isEmpty());
+    }
+
+    private static CaseDetails getCaseDetails(String caseDetails) throws IOException {
+        String caseDetailsWithHearings = FileUtils.readFileToString(new File(caseDetails),
+            StandardCharsets.UTF_8.name());
+        ObjectMapper mapper = Jackson2ObjectMapperBuilder.json().build();
+        return mapper.readerFor(CaseDetails.class).readValue(caseDetailsWithHearings);
+    }
+}

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -192,7 +192,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
 
     /*
        scenario4:
-       Given major status with id 18
+       Given major status with id 18 is the current appeal status
        And postponed_granted Yes
        And no hearing element present in Delta
        And there is a hearingId matching to the postponementHearingId in the existing case in CCD

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -3,12 +3,6 @@ package uk.gov.hmcts.reform.sscs.services.mapper;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.anyListOf;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
@@ -23,7 +17,6 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Matchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -36,7 +29,6 @@ import uk.gov.hmcts.reform.sscs.models.GapsEvent;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.PostponementRequests;
-import uk.gov.hmcts.reform.sscs.models.idam.IdamTokens;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
 import uk.gov.hmcts.reform.sscs.services.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.services.sftp.SftpChannelAdapter;
@@ -102,7 +94,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
             coreCaseDataProperties.getJurisdictionId(),
             coreCaseDataProperties.getCaseTypeId(),
             ImmutableMap.of("case.caseReference", appeal.getAppealCaseRefNum())
-        )).willReturn(Collections.singletonList(getCaseDetails(CASE_DETAILS_WITH_HEARINGS_JSON)));
+        )).willReturn(Collections.singletonList(getCaseDetails()));
 
         events = caseDataEventBuilder.buildPostponedEvent(appeal);
 
@@ -149,9 +141,63 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
         assertEquals(expectedDate, actualPostponedDate);
     }
 
+    /*
+      scenario3:
+      Given minor status with id 27
+      And multiple hearing objects
+      And two postponed request elements with the granted field to 'Y'
+      And one of them matching the hearing id field to the hearing in the existing Case in CDD
+      Then one postponed element is created
+   */
+    @Test
+    public void givenScenario3ThenPostponedIsCreated()
+        throws Exception {
+        AppealCase appeal = AppealCase.builder()
+            .appealCaseCaseCodeId("1")
+            .appealCaseRefNum("SC068/17/00011")
+            .majorStatus(Collections.singletonList(
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), APPEAL_RECEIVED_DATE)
+            ))
+            .minorStatus(Collections.singletonList(
+                super.buildMinorStatusGivenIdAndDate("27", MINOR_STATUS_ID_27_DATE)))
+            .hearing(Arrays.asList(
+                Hearing.builder().hearingId("1").build(),
+                Hearing.builder().hearingId("2").build()
+            ))
+            .postponementRequests(Arrays.asList(
+                new PostponementRequests(
+                    "Y", "6", null, null),
+                new PostponementRequests(
+                    "Y", "", null, null)
+            ))
+            .build();
 
-    private static CaseDetails getCaseDetails(String caseDetails) throws IOException {
-        String caseDetailsWithHearings = FileUtils.readFileToString(new File(caseDetails),
+
+        given(idamService.getIdamOauth2Token()).willReturn("oauth2Token");
+        given(idamService.generateServiceAuthorization()).willReturn("serviceToken");
+
+        given(coreCaseDataApi.searchForCaseworker(
+            "oauth2Token",
+            "serviceToken",
+            coreCaseDataProperties.getUserId(),
+            coreCaseDataProperties.getJurisdictionId(),
+            coreCaseDataProperties.getCaseTypeId(),
+            ImmutableMap.of("case.caseReference", appeal.getAppealCaseRefNum())
+        )).willReturn(Collections.singletonList(getCaseDetails()));
+
+        events = caseDataEventBuilder.buildPostponedEvent(appeal);
+
+        assertEquals("One postponed event expected here", 1, events.size());
+        assertEquals("type expected is postponed", GapsEvent.HEARING_POSTPONED.getType(),
+            events.get(0).getValue().getType());
+        LocalDateTime actualPostponedDate = LocalDateTime.parse(events.get(0).getValue().getDate());
+        LocalDateTime expectedDate = ZonedDateTime.parse(MINOR_STATUS_ID_27_DATE).toLocalDateTime();
+        assertEquals(expectedDate, actualPostponedDate);
+    }
+
+    private static CaseDetails getCaseDetails() throws IOException {
+        String caseDetailsWithHearings = FileUtils.readFileToString(
+            new File(CaseDataEventBuilderTest.CASE_DETAILS_WITH_HEARINGS_JSON),
             StandardCharsets.UTF_8.name());
         ObjectMapper mapper = Jackson2ObjectMapperBuilder.json().build();
         return mapper.readerFor(CaseDetails.class).readValue(caseDetailsWithHearings);

--- a/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/IntegrationTests/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -1,19 +1,29 @@
 package uk.gov.hmcts.reform.sscs.services.mapper;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Matchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -26,6 +36,7 @@ import uk.gov.hmcts.reform.sscs.models.GapsEvent;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.PostponementRequests;
+import uk.gov.hmcts.reform.sscs.models.idam.IdamTokens;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
 import uk.gov.hmcts.reform.sscs.services.idam.IdamService;
 import uk.gov.hmcts.reform.sscs.services.sftp.SftpChannelAdapter;
@@ -49,6 +60,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
     private CoreCaseDataProperties coreCaseDataProperties;
 
     private static final String CASE_DETAILS_WITH_HEARINGS_JSON = "src/test/resources/CaseDetailsWithHearings.json";
+    private List<Events> events;
 
     /*
        scenario1:
@@ -92,10 +104,51 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
             ImmutableMap.of("case.caseReference", appeal.getAppealCaseRefNum())
         )).willReturn(Collections.singletonList(getCaseDetails(CASE_DETAILS_WITH_HEARINGS_JSON)));
 
-        List<Events> events = caseDataEventBuilder.buildPostponedEvent(appeal);
+        events = caseDataEventBuilder.buildPostponedEvent(appeal);
 
         assertTrue("No postponed event expected here", events.isEmpty());
     }
+
+    /*
+       scenario2:
+       Given minor status with id 27
+       And multiple hearing objects
+       And two postponed request elements with the granted field to 'Y'
+       And one of them matching the hearing id field to the hearing in the Delta
+       Then one postponed element is created
+    */
+    @Test
+    public void givenScenario2ThenPostponedIsCreated() {
+        AppealCase appeal = AppealCase.builder()
+            .appealCaseCaseCodeId("1")
+            .majorStatus(Collections.singletonList(
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), APPEAL_RECEIVED_DATE)
+            ))
+            .minorStatus(Collections.singletonList(
+                super.buildMinorStatusGivenIdAndDate("27", MINOR_STATUS_ID_27_DATE)))
+            .hearing(Arrays.asList(
+                Hearing.builder().hearingId("1").build(),
+                Hearing.builder().hearingId("2").build()
+            ))
+            .postponementRequests(Arrays.asList(
+                new PostponementRequests(
+                    "Y", "1", null, null),
+                new PostponementRequests(
+                    "Y", "", null, null)
+            ))
+            .build();
+
+
+        events = caseDataEventBuilder.buildPostponedEvent(appeal);
+
+        assertEquals("One postponed event expected here", 1, events.size());
+        assertEquals("type expected is postponed", GapsEvent.HEARING_POSTPONED.getType(),
+            events.get(0).getValue().getType());
+        LocalDateTime actualPostponedDate = LocalDateTime.parse(events.get(0).getValue().getDate());
+        LocalDateTime expectedDate = ZonedDateTime.parse(MINOR_STATUS_ID_27_DATE).toLocalDateTime();
+        assertEquals(expectedDate, actualPostponedDate);
+    }
+
 
     private static CaseDetails getCaseDetails(String caseDetails) throws IOException {
         String caseDetailsWithHearings = FileUtils.readFileToString(new File(caseDetails),

--- a/src/e2e/java/uk.gov.hmcts.reform.sscs/functional/ProcessCaseFile.java
+++ b/src/e2e/java/uk.gov.hmcts.reform.sscs/functional/ProcessCaseFile.java
@@ -29,7 +29,6 @@ public class ProcessCaseFile {
 
     private final String caseloaderinstance = System.getenv("TEST_URL");
     private String filename;
-    private String outputdir = "src/test/resources/updates";
 
     @Autowired
     private SftpChannelAdapter sftpChannelAdapter;
@@ -37,6 +36,7 @@ public class ProcessCaseFile {
     @Before
     public void setup() throws ParserConfigurationException, TransformerException, IOException {
         GenerateXml.generateXmlForAppeals();
+        String outputdir = "src/test/resources/updates";
         copy(outputdir, filename);
     }
 

--- a/src/e2e/java/uk.gov.hmcts.reform.sscs/functional/ProcessCaseFile.java
+++ b/src/e2e/java/uk.gov.hmcts.reform.sscs/functional/ProcessCaseFile.java
@@ -3,10 +3,12 @@ package uk.gov.hmcts.reform.sscs.functional;
 import com.jcraft.jsch.ChannelSftp;
 import com.jcraft.jsch.SftpException;
 import io.restassured.RestAssured;
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
-import org.apache.commons.configuration.ConfigurationException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,16 +28,14 @@ import uk.gov.hmcts.reform.tools.GenerateXml;
 public class ProcessCaseFile {
 
     private final String caseloaderinstance = System.getenv("TEST_URL");
-    String filename;
-    String outputdir = "src/test/resources/updates";
-
+    private String filename;
+    private String outputdir = "src/test/resources/updates";
 
     @Autowired
     private SftpChannelAdapter sftpChannelAdapter;
 
-
     @Before
-    public void setup() throws ParserConfigurationException, TransformerException, IOException, ConfigurationException {
+    public void setup() throws ParserConfigurationException, TransformerException, IOException {
         GenerateXml.generateXmlForAppeals();
         copy(outputdir, filename);
     }
@@ -46,7 +46,7 @@ public class ProcessCaseFile {
 
     }
 
-    public void copy(String outputdir, String filename) {
+    private void copy(String outputdir, String filename) {
         ChannelSftp sftpChannel = sftpChannelAdapter.getSftpChannel();
         try {
             File folder = new File(outputdir);

--- a/src/e2e/java/uk.gov.hmcts.reform.sscs/smoke/GetSavedCase.java
+++ b/src/e2e/java/uk.gov.hmcts.reform.sscs/smoke/GetSavedCase.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.springframework.http.HttpStatus;
 
 public class GetSavedCase {
-    public String sscsCasePattern = "SC068/18/01217";
 
     private final String caseloaderinstance = System.getenv("TEST_URL");
 

--- a/src/e2e/java/uk/gov/hmcts/reform/tools/GenerateXml.java
+++ b/src/e2e/java/uk/gov/hmcts/reform/tools/GenerateXml.java
@@ -9,21 +9,18 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Comparator;
-import java.util.List;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
 import org.junit.runners.MethodSorters;
-import uk.gov.hmcts.reform.tools.builders.Appeal;
 import uk.gov.hmcts.reform.tools.enums.AppealTemplate;
 import uk.gov.hmcts.reform.tools.factory.AppealFactory;
 import uk.gov.hmcts.reform.tools.utils.XmlWriter;
 
 
 @SuppressWarnings({"PMD", "checkstyle:hideutilityclassconstructor"})
-
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class GenerateXml {
 
@@ -44,16 +41,16 @@ public class GenerateXml {
     private static void cleanUpDirectory(String directory) throws IOException {
         if (get(directory).toFile().exists()) {
             walk(get(directory), FOLLOW_LINKS)
-                    .sorted(Comparator.reverseOrder())
-                    .map(Path::toFile)
-                    .peek(System.out::println)
-                    .forEach(File::delete);
+                .sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .peek(System.out::println)
+                .forEach(File::delete);
         }
     }
 
 
     public static void generateXmlForAppeals() throws
-            IOException, TransformerException, ParserConfigurationException {
+        IOException, TransformerException, ParserConfigurationException {
 
         String createPath = "CreateAppeals";
 
@@ -68,8 +65,6 @@ public class GenerateXml {
         appealFactory.selectAppeal(xmlWriter, AppealTemplate.HEARD_FOR_DESTRUCTION, 1);
 
         xmlWriter.writeXml(OUTPUT_DIR);
-
-        List<Appeal> appeals = xmlWriter.getAppealWrittenToFile();
 
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/controller/test/functional/Functional.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/controller/test/functional/Functional.java
@@ -35,7 +35,7 @@ public class Functional {
             .idamOauth2Token(idamService.getIdamOauth2Token())
             .authenticationService(idamService.generateServiceAuthorization())
             .build();
-        return searchCcdService.findCaseByCaseRef("SC068/18/01217", idamTokens);
+        return searchCcdService.findCaseByCaseRef(referenceNumber, idamTokens);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/controller/test/functional/Functional.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/controller/test/functional/Functional.java
@@ -32,10 +32,10 @@ public class Functional {
     @ResponseBody
     public List<CaseDetails> getCase(@PathVariable String referenceNumber) {
         IdamTokens idamTokens = IdamTokens.builder()
-                .idamOauth2Token(idamService.getIdamOauth2Token())
-                .idamOauth2Token(idamService.generateServiceAuthorization())
-                .build();
-        return searchCcdService.findCaseByCaseRef(referenceNumber, idamTokens);
+            .idamOauth2Token(idamService.getIdamOauth2Token())
+            .authenticationService(idamService.generateServiceAuthorization())
+            .build();
+        return searchCcdService.findCaseByCaseRef("SC068/18/01217", idamTokens);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/controller/test/smoke/Smoke.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/controller/test/smoke/Smoke.java
@@ -23,7 +23,7 @@ public class Smoke {
     public List<CaseDetails> smoke() {
         IdamTokens idamTokens = IdamTokens.builder()
             .idamOauth2Token(idamService.getIdamOauth2Token())
-            .idamOauth2Token(idamService.generateServiceAuthorization())
+            .authenticationService(idamService.generateServiceAuthorization())
             .build();
         return searchCcdService.findCaseByCaseRef("SC068/18/01217", idamTokens);
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/models/deserialize/gaps2/AppealCase.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/models/deserialize/gaps2/AppealCase.java
@@ -40,6 +40,7 @@ public class AppealCase {
     private String appealCaseDateAppealMade;
     private String appealCaseDateAppealReceived;
     private List<PostponementRequests> postponementRequests;
+    private List<MinorStatus> minorStatus;
 
     public AppealCase(@JsonProperty("Appeal_Case_Date_of_Decision") String appealCaseDateOfDecision,
                       @JsonProperty("Admin_Team_Id") String adminTeamId,
@@ -59,7 +60,8 @@ public class AppealCase {
                       @JsonProperty("Appeal_Case_Case_Code_Id") String appealCaseCaseCodeId,
                       @JsonProperty("Appeal_Case_Date_Appeal_Made") String appealCaseDateAppealMade,
                       @JsonProperty("Appeal_Case_Date_Appeal_Received") String appealCaseDateAppealReceived,
-                      @JsonProperty("Postponement_Requests") List<PostponementRequests> postponementRequests) {
+                      @JsonProperty("Postponement_Requests") List<PostponementRequests> postponementRequests,
+                      @JsonProperty("Minor_Status") List<MinorStatus> minorStatus) {
         this.appealCaseDateOfDecision = appealCaseDateOfDecision;
         this.adminTeamId = adminTeamId;
         this.originatingOfficeId = originatingOfficeId;
@@ -79,6 +81,7 @@ public class AppealCase {
         this.appealCaseDateAppealMade = appealCaseDateAppealMade;
         this.appealCaseDateAppealReceived = appealCaseDateAppealReceived;
         this.postponementRequests = postponementRequests;
+        this.minorStatus = minorStatus;
     }
 
     @JsonIgnore

--- a/src/main/java/uk/gov/hmcts/reform/sscs/models/deserialize/gaps2/Hearing.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/models/deserialize/gaps2/Hearing.java
@@ -1,9 +1,11 @@
 package uk.gov.hmcts.reform.sscs.models.deserialize.gaps2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
 import lombok.Value;
 
 @Value
+@Builder
 public class Hearing {
     private String outcomeId;
     private String venueId;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/models/deserialize/gaps2/MinorStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/models/deserialize/gaps2/MinorStatus.java
@@ -1,0 +1,13 @@
+package uk.gov.hmcts.reform.sscs.models.deserialize.gaps2;
+
+import java.time.ZonedDateTime;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class MinorStatus {
+    String bfDate;
+    String statusId;
+    ZonedDateTime dateSet;
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/models/deserialize/gaps2/MinorStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/models/deserialize/gaps2/MinorStatus.java
@@ -1,13 +1,20 @@
 package uk.gov.hmcts.reform.sscs.models.deserialize.gaps2;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.ZonedDateTime;
-import lombok.Builder;
 import lombok.Value;
 
 @Value
-@Builder
 public class MinorStatus {
     String bfDate;
     String statusId;
     ZonedDateTime dateSet;
+
+    public MinorStatus(@JsonProperty("BF_Date") String bfDate,
+                       @JsonProperty("Status_Id") String statusId,
+                       @JsonProperty("Date_Set") ZonedDateTime dateSet) {
+        this.bfDate = bfDate;
+        this.statusId = statusId;
+        this.dateSet = dateSet;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/models/serialize/ccd/HearingDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/models/serialize/ccd/HearingDetails.java
@@ -3,11 +3,13 @@ package uk.gov.hmcts.reform.sscs.models.serialize.ccd;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Data;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Data
 @Builder
 public class HearingDetails {
@@ -15,21 +17,25 @@ public class HearingDetails {
     private String hearingDate;
     private String time;
     private String adjourned;
+    private String hearingId;
 
     @JsonCreator
     public HearingDetails(@JsonProperty("venue") Venue venue,
                           @JsonProperty("hearingDate") String hearingDate,
                           @JsonProperty("time") String time,
-                          @JsonProperty("adjourned") String adjourned) {
+                          @JsonProperty("adjourned") String adjourned,
+                          @JsonProperty("hearingId") String hearingId) {
 
         this.venue = venue;
         this.hearingDate = hearingDate;
         this.time = time;
         this.adjourned = adjourned;
+        this.hearingId = hearingId;
     }
 
     @JsonIgnore
     public String getHearingDateTime() {
         return hearingDate + time;
     }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilder.java
@@ -55,6 +55,7 @@ public class CaseDataBuilder {
     public List<Events> buildEvent(AppealCase appealCase) {
         List<Events> events = caseDataEventBuilder.buildMajorStatusEvents(appealCase);
         events.addAll(caseDataEventBuilder.buildPostponedEvent(appealCase));
+        events.addAll(caseDataEventBuilder.buildAdjournedEvents(appealCase));
         events.sort(Collections.reverseOrder());
         return events;
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilder.java
@@ -127,6 +127,7 @@ class CaseDataBuilder {
                         .hearingDate(hearing.getSessionDate().substring(0, 10))
                         .time((appealTime == null) ? "00:00:00" : appealTime.substring(11, 19))
                         .adjourned(isAdjourned(appealCase.getMajorStatus()) ? YES : NO)
+                        .hearingId(hearing.getHearingId())
                         .build();
 
                     hearingsList.add(Hearing.builder().value(hearings).build());

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilder.java
@@ -37,7 +37,7 @@ import uk.gov.hmcts.reform.sscs.services.refdata.ReferenceDataService;
 
 @Service
 @Slf4j
-public class CaseDataBuilder {
+class CaseDataBuilder {
 
     private static final String YES = "Yes";
     static final String NO = "No";
@@ -52,7 +52,7 @@ public class CaseDataBuilder {
         this.caseDataEventBuilder = caseDataEventBuilder;
     }
 
-    public List<Events> buildEvent(AppealCase appealCase) {
+    List<Events> buildEvent(AppealCase appealCase) {
         List<Events> events = caseDataEventBuilder.buildMajorStatusEvents(appealCase);
         events.addAll(caseDataEventBuilder.buildPostponedEvent(appealCase));
         events.addAll(caseDataEventBuilder.buildAdjournedEvents(appealCase));
@@ -60,14 +60,14 @@ public class CaseDataBuilder {
         return events;
     }
 
-    public Identity buildIdentity(Parties party, AppealCase appealCase) {
+    Identity buildIdentity(Parties party, AppealCase appealCase) {
         return Identity.builder()
             .dob(DateHelper.getValidDateOrTime(party.getDob(), true))
             .nino(appealCase.getAppealCaseNino())
             .build();
     }
 
-    public Name buildName(Parties party) {
+    Name buildName(Parties party) {
         return Name.builder()
             .title(party.getTitle())
             .firstName(party.getInitials())
@@ -75,7 +75,7 @@ public class CaseDataBuilder {
             .build();
     }
 
-    public Contact buildContact(Parties party) {
+    Contact buildContact(Parties party) {
         return Contact.builder()
             .email(party.getEmail())
             .phone(party.getPhone1())
@@ -83,20 +83,20 @@ public class CaseDataBuilder {
             .build();
     }
 
-    public BenefitType buildBenefitType(AppealCase appealCase) {
+    BenefitType buildBenefitType(AppealCase appealCase) {
         String benefitType = referenceDataService.getBenefitType(appealCase.getAppealCaseCaseCodeId());
         return BenefitType.builder()
             .code(benefitType)
             .build();
     }
 
-    public HearingOptions buildHearingOptions(Parties party) {
+    HearingOptions buildHearingOptions(Parties party) {
         return HearingOptions.builder()
             .other(Y.equals(party.getDisabilityNeeds()) ? YES : NO)
             .build();
     }
 
-    public List<Hearing> buildHearings(AppealCase appealCase) {
+    List<Hearing> buildHearings(AppealCase appealCase) {
         List<Hearing> hearingsList = new ArrayList<>();
         HearingDetails hearings;
 
@@ -139,7 +139,7 @@ public class CaseDataBuilder {
         return hearingsList;
     }
 
-    public Evidence buildEvidence(AppealCase appealCase) {
+    Evidence buildEvidence(AppealCase appealCase) {
         List<Documents> documentsList = new ArrayList<>();
         Doc doc;
 
@@ -160,7 +160,7 @@ public class CaseDataBuilder {
             .build();
     }
 
-    public List<DwpTimeExtension> buildDwpTimeExtensions(AppealCase appealCase) {
+    List<DwpTimeExtension> buildDwpTimeExtensions(AppealCase appealCase) {
         List<DwpTimeExtension> dwpTimeExtensionList = new ArrayList<>();
         List<PostponementRequests> postponementRequestsList = appealCase.getPostponementRequests();
         if (postponementRequestsList != null) {
@@ -185,7 +185,7 @@ public class CaseDataBuilder {
         return majorStatusList.stream().anyMatch(majorStatus -> "92".equals(majorStatus.getStatusId()));
     }
 
-    public Subscriptions buildSubscriptions() {
+    Subscriptions buildSubscriptions() {
         Subscription appellantSubscription = Subscription.builder()
             .email("")
             .mobile("")

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilder.java
@@ -41,7 +41,8 @@ class CaseDataBuilder {
 
     private static final String YES = "Yes";
     static final String NO = "No";
-    private static final String Y = "Y";
+    private static final String DISABILITY_NEEDS = "Y";
+    private static final String POSTPONEMENT_GRANTED = "Y";
 
     private final ReferenceDataService referenceDataService;
     private final CaseDataEventBuilder caseDataEventBuilder;
@@ -92,7 +93,7 @@ class CaseDataBuilder {
 
     HearingOptions buildHearingOptions(Parties party) {
         return HearingOptions.builder()
-            .other(Y.equals(party.getDisabilityNeeds()) ? YES : NO)
+            .other(DISABILITY_NEEDS.equals(party.getDisabilityNeeds()) ? YES : NO)
             .build();
     }
 
@@ -168,7 +169,7 @@ class CaseDataBuilder {
                 postponementRequests -> {
                     DwpTimeExtensionDetails dwpTimeExtensionDetails = DwpTimeExtensionDetails.builder()
                         .requested(postponementRequests.getPostponementReasonId() != null ? YES : NO)
-                        .granted(Y.equals(postponementRequests.getPostponementGranted()) ? YES : NO)
+                        .granted(POSTPONEMENT_GRANTED.equals(postponementRequests.getPostponementGranted()) ? YES : NO)
                         .build();
                     DwpTimeExtension dwpTimeExtension = DwpTimeExtension.builder()
                         .value(dwpTimeExtensionDetails)

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilder.java
@@ -59,6 +59,7 @@ public class CaseDataBuilder {
                 Events.builder()
                     .value(Event.builder()
                         .type(GapsEvent.HEARING_POSTPONED.getType())
+                        .date(appealCase.getMinorStatus().get(0).getDateSet().toString())
                         .build())
                     .build());
         }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilder.java
@@ -53,8 +53,8 @@ public class CaseDataBuilder {
     }
 
     public List<Events> buildEvent(AppealCase appealCase) {
-        List<Events> events = caseDataEventBuilder.buildPostponedEvent(appealCase);
-        events.addAll(caseDataEventBuilder.buildMajorStatusEvents(appealCase));
+        List<Events> events = caseDataEventBuilder.buildMajorStatusEvents(appealCase);
+        events.addAll(caseDataEventBuilder.buildPostponedEvent(appealCase));
         events.sort(Collections.reverseOrder());
         return events;
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilder.java
@@ -66,7 +66,8 @@ public class CaseDataBuilder {
             events.add(Events.builder()
                 .value(Event.builder()
                     .type(GapsEvent.HEARING_POSTPONED.getType())
-                    .date(appealCase.getMinorStatus().get(0).getDateSet().toString())
+                    .date(appealCase.getMinorStatus().get(0).getDateSet().toLocalDateTime().toString())
+                    .description(GapsEvent.HEARING_POSTPONED.getDescription())
                     .build())
                 .build());
         }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilder.java
@@ -54,17 +54,22 @@ public class CaseDataBuilder {
     }
 
     public List<Events> buildEvent(AppealCase appealCase) {
-        if (minorStatusIsNotNullAndIsNotEmpty(appealCase.getMinorStatus())) {
-            return Collections.singletonList(
-                Events.builder()
-                    .value(Event.builder()
-                        .type(GapsEvent.HEARING_POSTPONED.getType())
-                        .date(appealCase.getMinorStatus().get(0).getDateSet().toString())
-                        .build())
-                    .build());
-        }
-        List<Events> events = buildMajorStatusEvents(appealCase);
+        List<Events> events = buildPostponedEvent(appealCase);
+        events.addAll(buildMajorStatusEvents(appealCase));
         events.sort(Collections.reverseOrder());
+        return events;
+    }
+
+    private List<Events> buildPostponedEvent(AppealCase appealCase) {
+        List<Events> events = new ArrayList<>();
+        if (minorStatusIsNotNullAndIsNotEmpty(appealCase.getMinorStatus())) {
+            events.add(Events.builder()
+                .value(Event.builder()
+                    .type(GapsEvent.HEARING_POSTPONED.getType())
+                    .date(appealCase.getMinorStatus().get(0).getDateSet().toString())
+                    .build())
+                .build());
+        }
         return events;
     }
 
@@ -82,7 +87,6 @@ public class CaseDataBuilder {
                     .description(gapsEvent.getDescription())
                     .date(majorStatus.getDateSet().toLocalDateTime().toString())
                     .build();
-
                 events.add(Events.builder()
                     .value(event)
                     .build());

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -45,17 +45,25 @@ class CaseDataEventBuilder {
     }
 
     List<Events> buildPostponedEvent(AppealCase appealCase) {
-        MajorStatus majorStatus = getMajorStatusFromAppealCase(appealCase.getMajorStatus());
-        if (areConditionsFromMajorStatusToCreatePostponedMet(appealCase, majorStatus)) {
-            return Collections.singletonList(buildNewPostponedEvent(majorStatus.getDateSet()));
-        }
+        List<Events> events = buildPostponeEventFromMajorStatus(appealCase);
+        return events.isEmpty() ? buildPostponedEventFromMinorStatus(appealCase) : events;
+    }
 
+    private List<Events> buildPostponedEventFromMinorStatus(AppealCase appealCase) {
         if (minorStatusIsNotNullAndIsNotEmpty(appealCase.getMinorStatus())) {
             return appealCase.getMinorStatus().stream()
                 .filter(minorStatus -> areConditionsToCreatePostponedEventMet(minorStatus.getStatusId(), appealCase))
                 .map(minorStatus -> buildNewPostponedEvent(minorStatus.getDateSet()))
                 .distinct()
                 .collect(Collectors.toList());
+        }
+        return Collections.emptyList();
+    }
+
+    private List<Events> buildPostponeEventFromMajorStatus(AppealCase appealCase) {
+        MajorStatus majorStatus = getMajorStatusFromAppealCase(appealCase.getMajorStatus());
+        if (areConditionsFromMajorStatusToCreatePostponedMet(appealCase, majorStatus)) {
+            return Collections.singletonList(buildNewPostponedEvent(majorStatus.getDateSet()));
         }
         return Collections.emptyList();
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.sscs.services.mapper;
 
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -82,7 +83,7 @@ public class CaseDataEventBuilder {
                         if (outcomeId >= 110 && outcomeId <= 126) {
                             Event adjournedEvent = Event.builder()
                                 .type(GapsEvent.HEARING_ADJOURNED.getType())
-                                .date(hearing.getSessionDate())
+                                .date(getLocalDateTime(hearing.getSessionDate()))
                                 .description(GapsEvent.HEARING_ADJOURNED.getDescription())
                                 .build();
 
@@ -95,5 +96,12 @@ public class CaseDataEventBuilder {
             return  events;
         }
         return Collections.emptyList();
+    }
+
+    private String getLocalDateTime(String zonedDateTimeWithOffset) {
+        return ZonedDateTime
+            .parse(zonedDateTimeWithOffset)
+            .toLocalDateTime()
+            .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -94,6 +94,6 @@ public class CaseDataEventBuilder {
             );
             return  events;
         }
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -89,9 +89,11 @@ class CaseDataEventBuilder {
         }
 
         if (minorStatusIdIs27AndMoreThanOnePostponementRequest(statusId, appealCase)) {
-            if (postponedEventInferredFromDelta.matchToHearingId(appealCase.getPostponementRequests(),
+            if (appealCase.getHearing() != null && !appealCase.getHearing().isEmpty()
+                && postponedEventInferredFromDelta.matchToHearingId(appealCase.getPostponementRequests(),
                 appealCase.getHearing())) {
                 return true;
+
             }
             return postponedEventInferredFromCcd.matchToHearingId(appealCase.getPostponementRequests(),
                 retrieveHearingsFromCaseInCcd(appealCase));

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -73,27 +73,25 @@ public class CaseDataEventBuilder {
 
 
     public List<Events> buildAdjournedEvents(AppealCase appealCase) {
-
         if (null != appealCase.getHearing() && !appealCase.getHearing().isEmpty()) {
             List<Events> events = new ArrayList<>();
             appealCase.getHearing().stream()
                 .filter(hearing -> null != hearing.getOutcomeId())
                 .forEach(hearing -> {
-                        int outcomeId = Integer.parseInt(hearing.getOutcomeId());
-                        if (outcomeId >= 110 && outcomeId <= 126) {
-                            Event adjournedEvent = Event.builder()
-                                .type(GapsEvent.HEARING_ADJOURNED.getType())
-                                .date(getLocalDateTime(hearing.getSessionDate()))
-                                .description(GapsEvent.HEARING_ADJOURNED.getDescription())
-                                .build();
+                    int outcomeId = Integer.parseInt(hearing.getOutcomeId());
+                    if (outcomeId >= 110 && outcomeId <= 126) {
+                        Event adjournedEvent = Event.builder()
+                            .type(GapsEvent.HEARING_ADJOURNED.getType())
+                            .date(getLocalDateTime(hearing.getSessionDate()))
+                            .description(GapsEvent.HEARING_ADJOURNED.getDescription())
+                            .build();
 
-                            events.add(Events.builder()
-                                .value(adjournedEvent)
-                                .build());
-                        }
-                }
-            );
-            return  events;
+                        events.add(Events.builder()
+                            .value(adjournedEvent)
+                            .build());
+                    }
+                });
+            return events;
         }
         return Collections.emptyList();
     }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -18,7 +18,7 @@ import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
 @Service
 public class CaseDataEventBuilder {
 
-    public List<Events> buildPostponedEvent(AppealCase appealCase) {
+    List<Events> buildPostponedEvent(AppealCase appealCase) {
         if (minorStatusIsNotNullAndIsNotEmpty(appealCase.getMinorStatus())) {
             return appealCase.getMinorStatus().stream()
                 .filter(minorStatus -> isValidMinorStatus(minorStatus.getStatusId(),

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -62,11 +62,12 @@ class CaseDataEventBuilder {
     }
 
     private List<Events> buildPostponeEventFromMajorStatus(AppealCase appealCase) {
-        MajorStatus majorStatus = getLatestMajorStatusFromAppealCase(appealCase.getMajorStatus());
-        if (areConditionsFromMajorStatusToCreatePostponedMet(appealCase, majorStatus)) {
-            return Collections.singletonList(buildNewPostponedEvent(majorStatus.getDateSet()));
-        }
-        return Collections.emptyList();
+        return appealCase.getMajorStatus().stream()
+            .filter(majorStatus -> majorStatus.getStatusId().equals(GapsEvent.RESPONSE_RECEIVED.getStatus()))
+            .filter(majorStatus -> areConditionsFromMajorStatusToCreatePostponedMet(appealCase, majorStatus))
+            .map(majorStatus -> buildNewPostponedEvent(majorStatus.getDateSet()))
+            .distinct()
+            .collect(Collectors.toList());
     }
 
     private boolean areConditionsFromMajorStatusToCreatePostponedMet(AppealCase appealCase, MajorStatus majorStatus) {
@@ -163,7 +164,7 @@ class CaseDataEventBuilder {
         return gapsEvent.getStatus().equals("27");
     }
 
-    public List<Events> buildAdjournedEvents(AppealCase appealCase) {
+    List<Events> buildAdjournedEvents(AppealCase appealCase) {
         if (null != appealCase.getHearing() && !appealCase.getHearing().isEmpty()) {
             List<Events> events = new ArrayList<>();
             appealCase.getHearing().stream()

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -4,6 +4,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,7 +62,7 @@ class CaseDataEventBuilder {
     }
 
     private List<Events> buildPostponeEventFromMajorStatus(AppealCase appealCase) {
-        MajorStatus majorStatus = getMajorStatusFromAppealCase(appealCase.getMajorStatus());
+        MajorStatus majorStatus = getLatestMajorStatusFromAppealCase(appealCase.getMajorStatus());
         if (areConditionsFromMajorStatusToCreatePostponedMet(appealCase, majorStatus)) {
             return Collections.singletonList(buildNewPostponedEvent(majorStatus.getDateSet()));
         }
@@ -81,9 +82,8 @@ class CaseDataEventBuilder {
             .isEmpty();
     }
 
-    //todo: get the latest major status id 18
-    private MajorStatus getMajorStatusFromAppealCase(List<MajorStatus> majorStatus) {
-        return majorStatus.get(0);
+    private MajorStatus getLatestMajorStatusFromAppealCase(List<MajorStatus> majorStatus) {
+        return Collections.max(majorStatus, Comparator.comparing(MajorStatus::getDateSet));
     }
 
     private boolean areConditionsToCreatePostponedEventMet(String statusId, AppealCase appealCase) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -76,19 +76,20 @@ public class CaseDataEventBuilder {
         if (null != appealCase.getHearing() && !appealCase.getHearing().isEmpty()) {
             List<Events> events = new ArrayList<>();
             appealCase.getHearing().stream()
+                .filter(hearing -> null != hearing.getOutcomeId())
                 .forEach(hearing -> {
-                    int outcomeId = Integer.parseInt(hearing.getOutcomeId());
-                    if (outcomeId >= 110 && outcomeId <= 126) {
-                        Event adjournedEvent = Event.builder()
-                            .type(GapsEvent.HEARING_ADJOURNED.getType())
-                            .date(hearing.getSessionDate())
-                            .description(GapsEvent.HEARING_ADJOURNED.getDescription())
-                            .build();
+                        int outcomeId = Integer.parseInt(hearing.getOutcomeId());
+                        if (outcomeId >= 110 && outcomeId <= 126) {
+                            Event adjournedEvent = Event.builder()
+                                .type(GapsEvent.HEARING_ADJOURNED.getType())
+                                .date(hearing.getSessionDate())
+                                .description(GapsEvent.HEARING_ADJOURNED.getDescription())
+                                .build();
 
-                        events.add(Events.builder()
-                            .value(adjournedEvent)
-                            .build());
-                    }
+                            events.add(Events.builder()
+                                .value(adjournedEvent)
+                                .build());
+                        }
                 }
             );
             return  events;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -31,11 +31,6 @@ class CaseDataEventBuilder {
     }
 
     private boolean areConditionsToCreatePostponedEventMet(String statusId, AppealCase appealCase) {
-        //fixme remove minor status id 26 logic
-        if ("26".equals(statusId)) {
-            return true;
-        }
-
         if (minorStatusIdIs27AndThereIsOnlyOnePostponementRequest(statusId, appealCase)) {
             return true;
         }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -4,7 +4,6 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,7 +46,8 @@ class CaseDataEventBuilder {
 
     List<Events> buildPostponedEvent(AppealCase appealCase) {
         List<Events> events = buildPostponeEventFromMajorStatus(appealCase);
-        return events.isEmpty() ? buildPostponedEventFromMinorStatus(appealCase) : events;
+        events.addAll(buildPostponedEventFromMinorStatus(appealCase));
+        return events;
     }
 
     private List<Events> buildPostponedEventFromMinorStatus(AppealCase appealCase) {
@@ -81,10 +81,6 @@ class CaseDataEventBuilder {
             .filter(postponementRequests -> "Y".equals(postponementRequests.getPostponementGranted()))
             .collect(Collectors.toList())
             .isEmpty();
-    }
-
-    private MajorStatus getLatestMajorStatusFromAppealCase(List<MajorStatus> majorStatus) {
-        return Collections.max(majorStatus, Comparator.comparing(MajorStatus::getDateSet));
     }
 
     private boolean areConditionsToCreatePostponedEventMet(String statusId, AppealCase appealCase) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -72,24 +72,27 @@ public class CaseDataEventBuilder {
 
 
     public List<Events> buildAdjournedEvents(AppealCase appealCase) {
-        List<Events> events = new ArrayList<>();
 
-        appealCase.getHearing().stream()
-            .forEach(hearing -> {
-                int outcomeId = Integer.parseInt(hearing.getOutcomeId());
+        if (null != appealCase.getHearing() && !appealCase.getHearing().isEmpty()) {
+            List<Events> events = new ArrayList<>();
+            appealCase.getHearing().stream()
+                .forEach(hearing -> {
+                    int outcomeId = Integer.parseInt(hearing.getOutcomeId());
                     if (outcomeId >= 110 && outcomeId <= 126) {
-                    Event adjournedEvent = Event.builder()
-                        .type(GapsEvent.HEARING_ADJOURNED.getType())
-                        .date(hearing.getSessionDate())
-                        .description(GapsEvent.HEARING_ADJOURNED.getDescription())
-                        .build();
+                        Event adjournedEvent = Event.builder()
+                            .type(GapsEvent.HEARING_ADJOURNED.getType())
+                            .date(hearing.getSessionDate())
+                            .description(GapsEvent.HEARING_ADJOURNED.getDescription())
+                            .build();
 
-                    events.add(Events.builder()
-                        .value(adjournedEvent)
-                        .build());
+                        events.add(Events.builder()
+                            .value(adjournedEvent)
+                            .build());
                     }
                 }
-        );
-        return  events;
+            );
+            return  events;
+        }
+        return Collections.EMPTY_LIST;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -71,4 +71,25 @@ public class CaseDataEventBuilder {
     }
 
 
+    public List<Events> buildAdjournedEvents(AppealCase appealCase) {
+        List<Events> events = new ArrayList<>();
+
+        appealCase.getHearing().stream()
+            .forEach(hearing -> {
+                int outcomeId = Integer.parseInt(hearing.getOutcomeId());
+                    if (outcomeId >= 110 && outcomeId <= 126) {
+                    Event adjournedEvent = Event.builder()
+                        .type(GapsEvent.HEARING_ADJOURNED.getType())
+                        .date(hearing.getSessionDate())
+                        .description(GapsEvent.HEARING_ADJOURNED.getDescription())
+                        .build();
+
+                    events.add(Events.builder()
+                        .value(adjournedEvent)
+                        .build());
+                    }
+                }
+        );
+        return  events;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -56,7 +56,7 @@ class CaseDataEventBuilder {
                 appealCase.getHearing())) {
                 return true;
             }
-            List<uk.gov.hmcts.reform.sscs.models.serialize.ccd.Hearing> hearingList = retrieveHearingsFromCaseInCcd(
+            List<Hearing> hearingList = retrieveHearingsFromCaseInCcd(
                 appealCase);
             return postponedRequestMatchesToHearingIdInCcdCase(appealCase.getPostponementRequests(), hearingList);
         }
@@ -83,7 +83,7 @@ class CaseDataEventBuilder {
             .isEmpty();
     }
 
-    private List<uk.gov.hmcts.reform.sscs.models.serialize.ccd.Hearing> retrieveHearingsFromCaseInCcd(
+    private List<Hearing> retrieveHearingsFromCaseInCcd(
         AppealCase appealCase) {
         IdamTokens idamTokens = IdamTokens.builder()
             .idamOauth2Token(idamService.getIdamOauth2Token())
@@ -97,15 +97,16 @@ class CaseDataEventBuilder {
 
     private boolean matchToHearingIdInCcdCase(
         PostponementRequests postponementRequest,
-        List<uk.gov.hmcts.reform.sscs.models.serialize.ccd.Hearing> hearingList) {
+        List<Hearing> hearingList) {
         return !hearingList.stream()
             .filter(hearing -> hearing.getValue().getHearingId().equals(postponementRequest.getAppealHearingId()))
             .collect(Collectors.toList())
             .isEmpty();
     }
 
-    private boolean matchToHearingIdInDelta(PostponementRequests postponementRequest,
-                                            List<uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing> hearingList) {
+    private boolean matchToHearingIdInDelta(
+        PostponementRequests postponementRequest,
+        List<uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing> hearingList) {
         return !hearingList.stream()
             .filter(hearing -> hearing.getHearingId().equals(postponementRequest.getAppealHearingId()))
             .collect(Collectors.toList())

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -38,7 +38,8 @@ public class CaseDataEventBuilder {
             .build();
     }
 
-    private boolean postponedEventIsNotPresentAlready(ZonedDateTime minorStatusDate, List<MajorStatus> majorStatusList) {
+    private boolean postponedEventIsNotPresentAlready(ZonedDateTime minorStatusDate,
+                                                      List<MajorStatus> majorStatusList) {
         return majorStatusList
             .stream()
             .filter(majorStatus -> majorStatus.getStatusId().equals(GapsEvent.HEARING_POSTPONED.getStatus()))

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -15,7 +15,8 @@ public class CaseDataEventBuilder {
 
     public List<Events> buildPostponedEvent(AppealCase appealCase) {
         List<Events> events = new ArrayList<>();
-        if (minorStatusIsNotNullAndIsNotEmpty(appealCase.getMinorStatus())) {
+        if (minorStatusIsNotNullAndIsNotEmpty(appealCase.getMinorStatus())
+            && minorStatusIdIsEqualTo26(appealCase)) {
             events.add(Events.builder()
                 .value(Event.builder()
                     .type(GapsEvent.HEARING_POSTPONED.getType())
@@ -25,6 +26,10 @@ public class CaseDataEventBuilder {
                 .build());
         }
         return events;
+    }
+
+    private boolean minorStatusIdIsEqualTo26(AppealCase appealCase) {
+        return "26".equals(appealCase.getMinorStatus().get(0).getStatusId());
     }
 
     private boolean minorStatusIsNotNullAndIsNotEmpty(List<MinorStatus> minorStatusList) {
@@ -48,7 +53,6 @@ public class CaseDataEventBuilder {
         }
         return events;
     }
-
 
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -31,20 +31,16 @@ class CaseDataEventBuilder {
     }
 
     private boolean areConditionsToCreatePostponedEventMet(String statusId, AppealCase appealCase) {
+        //fixme remove minor status id 26 logic
         if ("26".equals(statusId)) {
             return true;
         }
 
-        if ("27".equals(statusId) && appealCase.getPostponementRequests() != null
-            && !appealCase.getPostponementRequests().isEmpty()
-            && appealCase.getPostponementRequests().size() == 1
-            && "Y".equals(appealCase.getPostponementRequests().get(0).getPostponementGranted())) {
+        if (minorStatusIdIs27AndThereIsOnlyOnePostponementRequest(statusId, appealCase)) {
             return true;
-
         }
 
-        if ("27".equals(statusId) && appealCase.getPostponementRequests() != null
-            && !appealCase.getPostponementRequests().isEmpty()) {
+        if (minorStatusIdIs27AndMoreThanOnePostponementRequest(statusId, appealCase)) {
             return !appealCase.getPostponementRequests().stream()
                 .filter(postponementRequest -> "Y".equals(postponementRequest.getPostponementGranted()))
                 .filter(postponementRequest -> postponementRequest.getAppealHearingId().equals(
@@ -53,6 +49,18 @@ class CaseDataEventBuilder {
                 .isEmpty();
         }
         return false;
+    }
+
+    private boolean minorStatusIdIs27AndMoreThanOnePostponementRequest(String statusId, AppealCase appealCase) {
+        return "27".equals(statusId) && appealCase.getPostponementRequests() != null
+            && !appealCase.getPostponementRequests().isEmpty();
+    }
+
+    private boolean minorStatusIdIs27AndThereIsOnlyOnePostponementRequest(String statusId, AppealCase appealCase) {
+        return "27".equals(statusId) && appealCase.getPostponementRequests() != null
+            && !appealCase.getPostponementRequests().isEmpty()
+            && appealCase.getPostponementRequests().size() == 1
+            && "Y".equals(appealCase.getPostponementRequests().get(0).getPostponementGranted());
     }
 
     private Events buildNewPostponedEvent(ZonedDateTime dateSet) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -23,6 +23,7 @@ public class CaseDataEventBuilder {
                 .filter(minorStatus -> postponedEventIsNotPresentAlready(minorStatus.getDateSet(),
                     appealCase.getMajorStatus()))
                 .map(minorStatus -> buildNewPostponedEvent(minorStatus.getDateSet()))
+                .distinct()
                 .collect(Collectors.toList());
         }
         return Collections.emptyList();

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MajorStatus;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 import uk.gov.hmcts.reform.sscs.models.idam.IdamTokens;
-import uk.gov.hmcts.reform.sscs.models.serialize.ccd.CaseData;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Event;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Hearing;
@@ -77,10 +76,13 @@ class CaseDataEventBuilder {
     }
 
     private boolean isPostponementGranted(AppealCase appealCase) {
-        return !appealCase.getPostponementRequests().stream()
-            .filter(postponementRequests -> "Y".equals(postponementRequests.getPostponementGranted()))
-            .collect(Collectors.toList())
-            .isEmpty();
+        if (appealCase.getPostponementRequests() != null) {
+            return !appealCase.getPostponementRequests().stream()
+                .filter(postponementRequests -> "Y".equals(postponementRequests.getPostponementGranted()))
+                .collect(Collectors.toList())
+                .isEmpty();
+        }
+        return false;
     }
 
     private boolean areConditionsToCreatePostponedEventMet(String statusId, AppealCase appealCase) {
@@ -109,8 +111,10 @@ class CaseDataEventBuilder {
             .build();
         List<CaseDetails> caseDetailsList = searchCcdService.findCaseByCaseRef(appealCase.getAppealCaseRefNum(),
             idamTokens);
-        CaseData caseData = CcdUtil.getCaseData(caseDetailsList.get(0).getData());
-        return caseData.getHearings();
+        if (caseDetailsList != null && !caseDetailsList.isEmpty()) {
+            return CcdUtil.getCaseData(caseDetailsList.get(0).getData()).getHearings();
+        }
+        return Collections.emptyList();
     }
 
     private boolean minorStatusIdIs27AndMoreThanOnePostponementRequest(String statusId, AppealCase appealCase) {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.sscs.models.GapsEvent;
@@ -70,6 +71,7 @@ class CaseDataEventBuilder {
         return false;
     }
 
+    @Retryable
     private List<Hearing> retrieveHearingsFromCaseInCcd(AppealCase appealCase) {
         IdamTokens idamTokens = IdamTokens.builder()
             .idamOauth2Token(idamService.getIdamOauth2Token())

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilder.java
@@ -1,0 +1,54 @@
+package uk.gov.hmcts.reform.sscs.services.mapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.models.GapsEvent;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MajorStatus;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Event;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
+
+@Service
+public class CaseDataEventBuilder {
+
+    public List<Events> buildPostponedEvent(AppealCase appealCase) {
+        List<Events> events = new ArrayList<>();
+        if (minorStatusIsNotNullAndIsNotEmpty(appealCase.getMinorStatus())) {
+            events.add(Events.builder()
+                .value(Event.builder()
+                    .type(GapsEvent.HEARING_POSTPONED.getType())
+                    .date(appealCase.getMinorStatus().get(0).getDateSet().toLocalDateTime().toString())
+                    .description(GapsEvent.HEARING_POSTPONED.getDescription())
+                    .build())
+                .build());
+        }
+        return events;
+    }
+
+    private boolean minorStatusIsNotNullAndIsNotEmpty(List<MinorStatus> minorStatusList) {
+        return minorStatusList != null && !minorStatusList.isEmpty();
+    }
+
+    public List<Events> buildMajorStatusEvents(AppealCase appealCase) {
+        List<Events> events = new ArrayList<>();
+        for (MajorStatus majorStatus : appealCase.getMajorStatus()) {
+            GapsEvent gapsEvent = GapsEvent.getGapsEventByStatus(majorStatus.getStatusId());
+            if (gapsEvent != null) {
+                Event event = Event.builder()
+                    .type(gapsEvent.getType())
+                    .description(gapsEvent.getDescription())
+                    .date(majorStatus.getDateSet().toLocalDateTime().toString())
+                    .build();
+                events.add(Events.builder()
+                    .value(event)
+                    .build());
+            }
+        }
+        return events;
+    }
+
+
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/PostponedEventInferredFromCcd.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/PostponedEventInferredFromCcd.java
@@ -10,11 +10,14 @@ import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Hearing;
 public class PostponedEventInferredFromCcd implements PostponedEventService<Hearing> {
     @Override
     public boolean matchToHearingId(List<PostponementRequests> postponementRequests, List<Hearing> hearingList) {
-        return !postponementRequests.stream()
-            .filter(postponementRequest -> "Y".equals(postponementRequest.getPostponementGranted()))
-            .filter(postponementRequest -> matchToHearingIdInCcdCase(postponementRequest, hearingList))
-            .collect(Collectors.toList())
-            .isEmpty();
+        if (hearingList != null && !hearingList.isEmpty()) {
+            return !postponementRequests.stream()
+                .filter(postponementRequest -> "Y".equals(postponementRequest.getPostponementGranted()))
+                .filter(postponementRequest -> matchToHearingIdInCcdCase(postponementRequest, hearingList))
+                .collect(Collectors.toList())
+                .isEmpty();
+        }
+        return false;
     }
 
     private boolean matchToHearingIdInCcdCase(

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/PostponedEventInferredFromCcd.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/PostponedEventInferredFromCcd.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.sscs.services.mapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.PostponementRequests;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Hearing;
+
+@Service
+public class PostponedEventInferredFromCcd implements PostponedEventService<Hearing> {
+    @Override
+    public boolean matchToHearingId(List<PostponementRequests> postponementRequests, List<Hearing> hearingList) {
+        return !postponementRequests.stream()
+            .filter(postponementRequest -> "Y".equals(postponementRequest.getPostponementGranted()))
+            .filter(postponementRequest -> matchToHearingIdInCcdCase(postponementRequest, hearingList))
+            .collect(Collectors.toList())
+            .isEmpty();
+    }
+
+    private boolean matchToHearingIdInCcdCase(
+        PostponementRequests postponementRequest,
+        List<Hearing> hearingList) {
+        return !hearingList.stream()
+            .filter(hearing -> hearing.getValue().getHearingId().equals(postponementRequest.getAppealHearingId()))
+            .collect(Collectors.toList())
+            .isEmpty();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/PostponedEventInferredFromDelta.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/PostponedEventInferredFromDelta.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.sscs.services.mapper;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.PostponementRequests;
+
+@Service
+public class PostponedEventInferredFromDelta implements PostponedEventService<Hearing> {
+    @Override
+    public boolean matchToHearingId(List<PostponementRequests> postponementRequests, List<Hearing> hearingList) {
+        return !postponementRequests.stream()
+            .filter(postponementRequest -> "Y".equals(postponementRequest.getPostponementGranted()))
+            .filter(postponementRequest -> matchToHearingIdInDelta(postponementRequest, hearingList))
+            .collect(Collectors.toList())
+            .isEmpty();
+
+    }
+
+    private boolean matchToHearingIdInDelta(
+        PostponementRequests postponementRequest,
+        List<Hearing> hearingList) {
+        return !hearingList.stream()
+            .filter(hearing -> hearing.getHearingId().equals(postponementRequest.getAppealHearingId()))
+            .collect(Collectors.toList())
+            .isEmpty();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/PostponedEventService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/PostponedEventService.java
@@ -1,0 +1,8 @@
+package uk.gov.hmcts.reform.sscs.services.mapper;
+
+import java.util.List;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.PostponementRequests;
+
+public interface PostponedEventService<T> {
+    boolean matchToHearingId(List<PostponementRequests> postponementRequests, List<T> hearingList);
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/sftp/SftpChannelAdapter.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/sftp/SftpChannelAdapter.java
@@ -43,7 +43,7 @@ public class SftpChannelAdapter {
                 try {
                     sftp.mkdir(dirName);
                 } catch (SftpException e1) {
-                    throw new SftpCustomException("Error creating directory", dirName, e);
+                    throw new SftpCustomException("Error creating directory", dirName, e); //NOPMD
                 }
             }
         }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -30,34 +30,34 @@ management:
 
 
 sftp:
-  keyLocation:  |
-                  -----BEGIN RSA PRIVATE KEY-----
-                  MIIEpgIBAAKCAQEAuB64U0n99/0/IuJM3SeiQaNLnWCKy+qMy+06D9UkpOrLHXpl
-                  6DkEQsTEZ58Xs00j+T/xlf6wfyl2qJn9B/ZtkdGeGAsdrmGtGQZ6tQLTPP1f0q7P
-                  DC568Rno5Y3r780VYC6+QQcLSgC5E+45jW52CS3sJuZTJ+4vt6huG+m5MbKMPOVe
-                  /QKnb20gNRsOGoX8oIHlbcogX62huUbAKgB9/eSj8kBSh1il19Xu6/WpBYORIZZM
-                  0Bh5DDQIMULNc965X9BlO50N15er3fftfIjv1pl91i4E1v/Rv6W5qIM3rgzLEjP2
-                  6n0+Lbhgpfc7yR/GoycUHJQrtd2PDKPjcv052wIDAQABAoIBAQCVxD9RWKWiXDhI
-                  KuY1GrEsTSULveUI3CBtHOmWyVzGXUqdDtvoGsDxgtb0JwADVGNHsxDTXtm4hkTD
-                  /oZJPNWBwI2lpx0cpM1FxvR3WvXy7XNNj+5RTVmp1taQK3JYnGyf0UXm5VD0gEQM
-                  B0J/XfPboaQvPDk2CNR9wx7Vy7ddySnyc0q9QEDo+Hb30QiacZDvvM2H08AXgegm
-                  FJTgR0xOgTncz/2Iw0xNL5rUA2+xnFvMeBqfOMLvSSvtTbwr4BQbup3r9uc5BYFC
-                  4NASRRh7ZLjzzAE2IOrv64/j0kjhSTliEsxLuhaVZgbhFVKuMW3ZwbG+7VVfY5ra
-                  IbErIPZZAoGBAOWeXHMGwzq8fPTKaHRRRpZ0Kk3DOWaLh2GuYn+XbjbfJTximzD9
-                  TgFXUhKau8wsvQ3t2udc9BbWX1mTFKUo/JJJPzp6HVHRSCozk4KFB3zdT2Lz45yA
-                  8jxaJFkGYiszpv+5tKU//cEHPr4pA+w7CPMk7RCe2VUkEXSHYXPA18TlAoGBAM1G
-                  Io1xTJO4cwPje3vlHmbEaNrjnTAere7T9LH1Lv1dPGxKhKlnbGLVo6CFsYjhV6DB
-                  bkSSiXlLT3uSuBakO1WRya0TLiYup7PCnTkjjivbFSxxbMqMxzi4RMx6pQde4qhd
-                  d3wf3JjY1JPIgw5OINVtbkTHW01LoLW4EaKPwde/AoGBAMPzuQGQq9rcL+bXNPzO
-                  v2Z2DAQArmOMfyQlJXmtSSkalTRLEhVklcUfN7MYyVscctoIOd9nvAYhO429rsij
-                  iadtSsAkphDEgMlC6odf71vnoW/Yok1U3WQTqSEwCWbE1ac2W6sKSQsJm8m8RtS6
-                  LJES2hxs8xtthFflkIyv7XLhAoGBAJZpHqZPb5IKJFSkGfZFg0o//qjtAV+iC0al
-                  jnXbNyw1ZjHfRGewva2J51SWweiPXZsQQRED4rG66imc70C/5C4mHgWwuS8HHqDM
-                  KFIW6HTgGhqvncyo7M110AuYjlXhQ+mkWwnbetOQhesnkEgqHUrl3VeOUCtKEB83
-                  Gczo01uXAoGBAIx3md2Bpj2q1320y6HDkfiTeBHBiO0lAmRUlxBYDD8j38voXgbc
-                  fVIJ9ZmQlS1z1kvWUf1hVR3DGFj+81i6mdfQvwIBrHVqjY21gXH4QnsMUd/f9K/V
-                  jExsyE94Udj65VZ9Jky5WEnEmicFE7JPaZm8Mnb67rMur93siXQ3oyL+
-                  -----END RSA PRIVATE KEY-----
+  keyLocation:  ${GAPS2_KEY_LOCATION:|
+                -----BEGIN RSA PRIVATE KEY-----
+                MIIEpgIBAAKCAQEAuB64U0n99/0/IuJM3SeiQaNLnWCKy+qMy+06D9UkpOrLHXpl
+                6DkEQsTEZ58Xs00j+T/xlf6wfyl2qJn9B/ZtkdGeGAsdrmGtGQZ6tQLTPP1f0q7P
+                DC568Rno5Y3r780VYC6+QQcLSgC5E+45jW52CS3sJuZTJ+4vt6huG+m5MbKMPOVe
+                /QKnb20gNRsOGoX8oIHlbcogX62huUbAKgB9/eSj8kBSh1il19Xu6/WpBYORIZZM
+                0Bh5DDQIMULNc965X9BlO50N15er3fftfIjv1pl91i4E1v/Rv6W5qIM3rgzLEjP2
+                6n0+Lbhgpfc7yR/GoycUHJQrtd2PDKPjcv052wIDAQABAoIBAQCVxD9RWKWiXDhI
+                KuY1GrEsTSULveUI3CBtHOmWyVzGXUqdDtvoGsDxgtb0JwADVGNHsxDTXtm4hkTD
+                /oZJPNWBwI2lpx0cpM1FxvR3WvXy7XNNj+5RTVmp1taQK3JYnGyf0UXm5VD0gEQM
+                B0J/XfPboaQvPDk2CNR9wx7Vy7ddySnyc0q9QEDo+Hb30QiacZDvvM2H08AXgegm
+                FJTgR0xOgTncz/2Iw0xNL5rUA2+xnFvMeBqfOMLvSSvtTbwr4BQbup3r9uc5BYFC
+                4NASRRh7ZLjzzAE2IOrv64/j0kjhSTliEsxLuhaVZgbhFVKuMW3ZwbG+7VVfY5ra
+                IbErIPZZAoGBAOWeXHMGwzq8fPTKaHRRRpZ0Kk3DOWaLh2GuYn+XbjbfJTximzD9
+                TgFXUhKau8wsvQ3t2udc9BbWX1mTFKUo/JJJPzp6HVHRSCozk4KFB3zdT2Lz45yA
+                8jxaJFkGYiszpv+5tKU//cEHPr4pA+w7CPMk7RCe2VUkEXSHYXPA18TlAoGBAM1G
+                Io1xTJO4cwPje3vlHmbEaNrjnTAere7T9LH1Lv1dPGxKhKlnbGLVo6CFsYjhV6DB
+                bkSSiXlLT3uSuBakO1WRya0TLiYup7PCnTkjjivbFSxxbMqMxzi4RMx6pQde4qhd
+                d3wf3JjY1JPIgw5OINVtbkTHW01LoLW4EaKPwde/AoGBAMPzuQGQq9rcL+bXNPzO
+                v2Z2DAQArmOMfyQlJXmtSSkalTRLEhVklcUfN7MYyVscctoIOd9nvAYhO429rsij
+                iadtSsAkphDEgMlC6odf71vnoW/Yok1U3WQTqSEwCWbE1ac2W6sKSQsJm8m8RtS6
+                LJES2hxs8xtthFflkIyv7XLhAoGBAJZpHqZPb5IKJFSkGfZFg0o//qjtAV+iC0al
+                jnXbNyw1ZjHfRGewva2J51SWweiPXZsQQRED4rG66imc70C/5C4mHgWwuS8HHqDM
+                KFIW6HTgGhqvncyo7M110AuYjlXhQ+mkWwnbetOQhesnkEgqHUrl3VeOUCtKEB83
+                Gczo01uXAoGBAIx3md2Bpj2q1320y6HDkfiTeBHBiO0lAmRUlxBYDD8j38voXgbc
+                fVIJ9ZmQlS1z1kvWUf1hVR3DGFj+81i6mdfQvwIBrHVqjY21gXH4QnsMUd/f9K/V
+                jExsyE94Udj65VZ9Jky5WEnEmicFE7JPaZm8Mnb67rMur93siXQ3oyL+
+                -----END RSA PRIVATE KEY-----}
   host: ${GAPS2_SFTP_HOST:localhost}
   port: ${GAPS2_SFTP_PORT:2222}
   username: ${GAPS2_SFTP_USER:sftp}
@@ -71,8 +71,8 @@ sscs.case.loader:
   url: ${SSCS_CASE_LOADER_URL:http://localhost:8082}
 
 logging.level:
-    org.springframework.web: ${LOG_LEVEL_SPRING_WEB:debug}
-    uk.gov.hmcts.reform.sscs: ${LOG_LEVEL_SSCS:debug}
+    org.springframework.web: ${LOG_LEVEL_SPRING_WEB:INFO}
+    uk.gov.hmcts.reform.sscs: ${LOG_LEVEL_SSCS:INFO}
 
 slot.name: ${SLOT:dev}
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -30,34 +30,34 @@ management:
 
 
 sftp:
-  keyLocation:  ${GAPS2_KEY_LOCATION:|
-                -----BEGIN RSA PRIVATE KEY-----
-                MIIEpgIBAAKCAQEAuB64U0n99/0/IuJM3SeiQaNLnWCKy+qMy+06D9UkpOrLHXpl
-                6DkEQsTEZ58Xs00j+T/xlf6wfyl2qJn9B/ZtkdGeGAsdrmGtGQZ6tQLTPP1f0q7P
-                DC568Rno5Y3r780VYC6+QQcLSgC5E+45jW52CS3sJuZTJ+4vt6huG+m5MbKMPOVe
-                /QKnb20gNRsOGoX8oIHlbcogX62huUbAKgB9/eSj8kBSh1il19Xu6/WpBYORIZZM
-                0Bh5DDQIMULNc965X9BlO50N15er3fftfIjv1pl91i4E1v/Rv6W5qIM3rgzLEjP2
-                6n0+Lbhgpfc7yR/GoycUHJQrtd2PDKPjcv052wIDAQABAoIBAQCVxD9RWKWiXDhI
-                KuY1GrEsTSULveUI3CBtHOmWyVzGXUqdDtvoGsDxgtb0JwADVGNHsxDTXtm4hkTD
-                /oZJPNWBwI2lpx0cpM1FxvR3WvXy7XNNj+5RTVmp1taQK3JYnGyf0UXm5VD0gEQM
-                B0J/XfPboaQvPDk2CNR9wx7Vy7ddySnyc0q9QEDo+Hb30QiacZDvvM2H08AXgegm
-                FJTgR0xOgTncz/2Iw0xNL5rUA2+xnFvMeBqfOMLvSSvtTbwr4BQbup3r9uc5BYFC
-                4NASRRh7ZLjzzAE2IOrv64/j0kjhSTliEsxLuhaVZgbhFVKuMW3ZwbG+7VVfY5ra
-                IbErIPZZAoGBAOWeXHMGwzq8fPTKaHRRRpZ0Kk3DOWaLh2GuYn+XbjbfJTximzD9
-                TgFXUhKau8wsvQ3t2udc9BbWX1mTFKUo/JJJPzp6HVHRSCozk4KFB3zdT2Lz45yA
-                8jxaJFkGYiszpv+5tKU//cEHPr4pA+w7CPMk7RCe2VUkEXSHYXPA18TlAoGBAM1G
-                Io1xTJO4cwPje3vlHmbEaNrjnTAere7T9LH1Lv1dPGxKhKlnbGLVo6CFsYjhV6DB
-                bkSSiXlLT3uSuBakO1WRya0TLiYup7PCnTkjjivbFSxxbMqMxzi4RMx6pQde4qhd
-                d3wf3JjY1JPIgw5OINVtbkTHW01LoLW4EaKPwde/AoGBAMPzuQGQq9rcL+bXNPzO
-                v2Z2DAQArmOMfyQlJXmtSSkalTRLEhVklcUfN7MYyVscctoIOd9nvAYhO429rsij
-                iadtSsAkphDEgMlC6odf71vnoW/Yok1U3WQTqSEwCWbE1ac2W6sKSQsJm8m8RtS6
-                LJES2hxs8xtthFflkIyv7XLhAoGBAJZpHqZPb5IKJFSkGfZFg0o//qjtAV+iC0al
-                jnXbNyw1ZjHfRGewva2J51SWweiPXZsQQRED4rG66imc70C/5C4mHgWwuS8HHqDM
-                KFIW6HTgGhqvncyo7M110AuYjlXhQ+mkWwnbetOQhesnkEgqHUrl3VeOUCtKEB83
-                Gczo01uXAoGBAIx3md2Bpj2q1320y6HDkfiTeBHBiO0lAmRUlxBYDD8j38voXgbc
-                fVIJ9ZmQlS1z1kvWUf1hVR3DGFj+81i6mdfQvwIBrHVqjY21gXH4QnsMUd/f9K/V
-                jExsyE94Udj65VZ9Jky5WEnEmicFE7JPaZm8Mnb67rMur93siXQ3oyL+
-                -----END RSA PRIVATE KEY-----}
+  keyLocation:  |
+                  -----BEGIN RSA PRIVATE KEY-----
+                  MIIEpgIBAAKCAQEAuB64U0n99/0/IuJM3SeiQaNLnWCKy+qMy+06D9UkpOrLHXpl
+                  6DkEQsTEZ58Xs00j+T/xlf6wfyl2qJn9B/ZtkdGeGAsdrmGtGQZ6tQLTPP1f0q7P
+                  DC568Rno5Y3r780VYC6+QQcLSgC5E+45jW52CS3sJuZTJ+4vt6huG+m5MbKMPOVe
+                  /QKnb20gNRsOGoX8oIHlbcogX62huUbAKgB9/eSj8kBSh1il19Xu6/WpBYORIZZM
+                  0Bh5DDQIMULNc965X9BlO50N15er3fftfIjv1pl91i4E1v/Rv6W5qIM3rgzLEjP2
+                  6n0+Lbhgpfc7yR/GoycUHJQrtd2PDKPjcv052wIDAQABAoIBAQCVxD9RWKWiXDhI
+                  KuY1GrEsTSULveUI3CBtHOmWyVzGXUqdDtvoGsDxgtb0JwADVGNHsxDTXtm4hkTD
+                  /oZJPNWBwI2lpx0cpM1FxvR3WvXy7XNNj+5RTVmp1taQK3JYnGyf0UXm5VD0gEQM
+                  B0J/XfPboaQvPDk2CNR9wx7Vy7ddySnyc0q9QEDo+Hb30QiacZDvvM2H08AXgegm
+                  FJTgR0xOgTncz/2Iw0xNL5rUA2+xnFvMeBqfOMLvSSvtTbwr4BQbup3r9uc5BYFC
+                  4NASRRh7ZLjzzAE2IOrv64/j0kjhSTliEsxLuhaVZgbhFVKuMW3ZwbG+7VVfY5ra
+                  IbErIPZZAoGBAOWeXHMGwzq8fPTKaHRRRpZ0Kk3DOWaLh2GuYn+XbjbfJTximzD9
+                  TgFXUhKau8wsvQ3t2udc9BbWX1mTFKUo/JJJPzp6HVHRSCozk4KFB3zdT2Lz45yA
+                  8jxaJFkGYiszpv+5tKU//cEHPr4pA+w7CPMk7RCe2VUkEXSHYXPA18TlAoGBAM1G
+                  Io1xTJO4cwPje3vlHmbEaNrjnTAere7T9LH1Lv1dPGxKhKlnbGLVo6CFsYjhV6DB
+                  bkSSiXlLT3uSuBakO1WRya0TLiYup7PCnTkjjivbFSxxbMqMxzi4RMx6pQde4qhd
+                  d3wf3JjY1JPIgw5OINVtbkTHW01LoLW4EaKPwde/AoGBAMPzuQGQq9rcL+bXNPzO
+                  v2Z2DAQArmOMfyQlJXmtSSkalTRLEhVklcUfN7MYyVscctoIOd9nvAYhO429rsij
+                  iadtSsAkphDEgMlC6odf71vnoW/Yok1U3WQTqSEwCWbE1ac2W6sKSQsJm8m8RtS6
+                  LJES2hxs8xtthFflkIyv7XLhAoGBAJZpHqZPb5IKJFSkGfZFg0o//qjtAV+iC0al
+                  jnXbNyw1ZjHfRGewva2J51SWweiPXZsQQRED4rG66imc70C/5C4mHgWwuS8HHqDM
+                  KFIW6HTgGhqvncyo7M110AuYjlXhQ+mkWwnbetOQhesnkEgqHUrl3VeOUCtKEB83
+                  Gczo01uXAoGBAIx3md2Bpj2q1320y6HDkfiTeBHBiO0lAmRUlxBYDD8j38voXgbc
+                  fVIJ9ZmQlS1z1kvWUf1hVR3DGFj+81i6mdfQvwIBrHVqjY21gXH4QnsMUd/f9K/V
+                  jExsyE94Udj65VZ9Jky5WEnEmicFE7JPaZm8Mnb67rMur93siXQ3oyL+
+                  -----END RSA PRIVATE KEY-----
   host: ${GAPS2_SFTP_HOST:localhost}
   port: ${GAPS2_SFTP_PORT:2222}
   username: ${GAPS2_SFTP_USER:sftp}
@@ -71,8 +71,8 @@ sscs.case.loader:
   url: ${SSCS_CASE_LOADER_URL:http://localhost:8082}
 
 logging.level:
-    org.springframework.web: ${LOG_LEVEL_SPRING_WEB:INFO}
-    uk.gov.hmcts.reform.sscs: ${LOG_LEVEL_SSCS:INFO}
+    org.springframework.web: ${LOG_LEVEL_SPRING_WEB:debug}
+    uk.gov.hmcts.reform.sscs: ${LOG_LEVEL_SSCS:debug}
 
 slot.name: ${SLOT:dev}
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/CaseDetailsUtils.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/CaseDetailsUtils.java
@@ -1,0 +1,20 @@
+package uk.gov.hmcts.reform.sscs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+public final class CaseDetailsUtils {
+
+    private CaseDetailsUtils() {
+    }
+
+    public static CaseDetails getCaseDetails(String caseDetails) throws IOException {
+        InputStream resourceAsStream = CaseDetailsUtils.class.getClassLoader().getResourceAsStream(caseDetails);
+        ObjectMapper mapper = Jackson2ObjectMapperBuilder.json().build();
+        return mapper.readerFor(CaseDetails.class).readValue(resourceAsStream);
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBase.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBase.java
@@ -4,7 +4,7 @@ import java.time.ZonedDateTime;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MajorStatus;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 
-class CaseDataBuilderBaseTest {
+class CaseDataBuilderBase {
 
     static final String HEARING_POSTPONED_DATE = "2018-05-24T00:00:00+01:00";
     static final String MINOR_STATUS_ID_27_DATE = "2018-05-24T00:00:00+01:00";

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBase.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBase.java
@@ -12,7 +12,7 @@ class CaseDataBuilderBase {
     static final String RESPONSE_RECEIVED_DATE = "2017-06-24T00:00:00+01:00";
 
     MajorStatus buildMajorStatusGivenStatusAndDate(String status, String testDate) {
-        return new MajorStatus("", status, "", ZonedDateTime.parse(testDate));
+        return new MajorStatus("", status, null, ZonedDateTime.parse(testDate));
     }
 
     MinorStatus buildMinorStatusGivenIdAndDate(String id, String date) {

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBase.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBase.java
@@ -9,6 +9,7 @@ class CaseDataBuilderBase {
     static final String HEARING_POSTPONED_DATE = "2018-05-24T00:00:00+01:00";
     static final String MINOR_STATUS_ID_27_DATE = "2018-05-24T00:00:00+01:00";
     static final String APPEAL_RECEIVED_DATE = "2017-05-24T00:00:00+01:00";
+    static final String RESPONSE_RECEIVED_DATE = "2017-06-24T00:00:00+01:00";
 
     MajorStatus buildMajorStatusGivenStatusAndDate(String status, String testDate) {
         return new MajorStatus("", status, "", ZonedDateTime.parse(testDate));

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.sscs.services.mapper;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import uk.gov.hmcts.reform.sscs.models.GapsEvent;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MajorStatus;
@@ -30,9 +29,8 @@ class CaseDataBuilderBaseTest {
         return new MajorStatus("", status, "", ZonedDateTime.parse(testDate));
     }
 
-    List<MinorStatus> getMinorStatusId26(String testDate) {
-        return Collections.singletonList(
-            new MinorStatus("", "26", ZonedDateTime.parse(testDate)));
+    MinorStatus getMinorStatusGivenIdAndDate(String id, ZonedDateTime date) {
+        return new MinorStatus("", id, date);
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
@@ -1,9 +1,6 @@
 package uk.gov.hmcts.reform.sscs.services.mapper;
 
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import uk.gov.hmcts.reform.sscs.models.GapsEvent;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MajorStatus;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 
@@ -12,24 +9,11 @@ class CaseDataBuilderBaseTest {
     static final String TEST_DATE2 = "2018-05-24T00:00:00+01:00";
     static final String TEST_DATE = "2017-05-24T00:00:00+01:00";
 
-    List<MajorStatus> buildMajorStatusGivenStatuses(GapsEvent... gapsEvents) {
-        ArrayList<MajorStatus> majorStatusList = new ArrayList<>(gapsEvents.length);
-        for (GapsEvent gapsEvent : gapsEvents) {
-            if (gapsEvent.equals(GapsEvent.APPEAL_RECEIVED)) {
-                majorStatusList.add(buildMajorStatusGivenDate(gapsEvent.getStatus(), TEST_DATE));
-            }
-            if (gapsEvent.equals(GapsEvent.HEARING_POSTPONED)) {
-                majorStatusList.add(buildMajorStatusGivenDate(gapsEvent.getStatus(), TEST_DATE2));
-            }
-        }
-        return majorStatusList;
-    }
-
-    private MajorStatus buildMajorStatusGivenDate(String status, String testDate) {
+    MajorStatus buildMajorStatusGivenStatusAndDate(String status, String testDate) {
         return new MajorStatus("", status, "", ZonedDateTime.parse(testDate));
     }
 
-    MinorStatus getMinorStatusGivenIdAndDate(String id, ZonedDateTime date) {
+    MinorStatus buildMinorStatusGivenIdAndDate(String id, ZonedDateTime date) {
         return new MinorStatus("", id, date);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
@@ -1,51 +1,37 @@
 package uk.gov.hmcts.reform.sscs.services.mapper;
 
-import static com.google.common.collect.Lists.newArrayList;
-
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.junit.Before;
-import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
-import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing;
+import uk.gov.hmcts.reform.sscs.models.GapsEvent;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MajorStatus;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 
-public class CaseDataBuilderBaseTest {
+@SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
+class CaseDataBuilderBaseTest {
 
-    static final String TEST_DATE2 = "2018-05-24T00:00:00+01:00";
-    static final String TEST_DATE = "2017-05-24T00:00:00+01:00";
+    private static final String TEST_DATE2 = "2018-05-24T00:00:00+01:00";
+    private static final String TEST_DATE = "2017-05-24T00:00:00+01:00";
 
-    private AppealCase appeal;
-
-    @Before
-    public void setUp() {
-        appeal = AppealCase.builder()
-            .appealCaseCaseCodeId("1")
-            .majorStatus(getAppealReceivedStatus())
-            .hearing(getHearing())
-            .minorStatus(Collections.singletonList(
-                new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE2))))
-            .build();
+    List<MajorStatus> buildMajorStatusGivenStatuses(GapsEvent... gapsEvents) {
+        ArrayList<MajorStatus> majorStatusList = new ArrayList<>(gapsEvents.length);
+        for (GapsEvent gapsEvent : gapsEvents) {
+            if (gapsEvent.equals(GapsEvent.APPEAL_RECEIVED)) {
+                majorStatusList.add(new MajorStatus("", gapsEvent.getStatus(), "",
+                    ZonedDateTime.parse(TEST_DATE))); //NOPMD
+            }
+            if (gapsEvent.equals(GapsEvent.HEARING_POSTPONED)) {
+                majorStatusList.add(new MajorStatus("", gapsEvent.getStatus(), "",
+                    ZonedDateTime.parse(TEST_DATE2))); //NOPMD
+            }
+        }
+        return majorStatusList;
     }
 
-    public List<MajorStatus> getAppealReceivedStatus() {
-        MajorStatus status = new MajorStatus("", "3", "", ZonedDateTime.parse(TEST_DATE));
-        return newArrayList(status);
+    List<MinorStatus> getMinorStatusId26() {
+        return Collections.singletonList(
+            new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE2)));
     }
 
-    public List<Hearing> getHearing() {
-        Hearing hearing = new Hearing("outcome",
-            "venue",
-            "outcomeDate",
-            "notificationDate",
-            "2017-05-24T00:00:00+01:00",
-            "2017-05-24T10:30:00+01:00",
-            "id");
-        return newArrayList(hearing);
-    }
-
-    public AppealCase getAppeal() {
-        return appeal;
-    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
@@ -8,7 +8,6 @@ import uk.gov.hmcts.reform.sscs.models.GapsEvent;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MajorStatus;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 
-@SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
 class CaseDataBuilderBaseTest {
 
     private static final String TEST_DATE2 = "2018-05-24T00:00:00+01:00";
@@ -18,15 +17,17 @@ class CaseDataBuilderBaseTest {
         ArrayList<MajorStatus> majorStatusList = new ArrayList<>(gapsEvents.length);
         for (GapsEvent gapsEvent : gapsEvents) {
             if (gapsEvent.equals(GapsEvent.APPEAL_RECEIVED)) {
-                majorStatusList.add(new MajorStatus("", gapsEvent.getStatus(), "",
-                    ZonedDateTime.parse(TEST_DATE))); //NOPMD
+                majorStatusList.add(buildMajorStatusGivenDate(gapsEvent.getStatus(), TEST_DATE));
             }
             if (gapsEvent.equals(GapsEvent.HEARING_POSTPONED)) {
-                majorStatusList.add(new MajorStatus("", gapsEvent.getStatus(), "",
-                    ZonedDateTime.parse(TEST_DATE2))); //NOPMD
+                majorStatusList.add(buildMajorStatusGivenDate(gapsEvent.getStatus(), TEST_DATE2));
             }
         }
         return majorStatusList;
+    }
+
+    private MajorStatus buildMajorStatusGivenDate(String status, String testDate) {
+        return new MajorStatus("", status, "", ZonedDateTime.parse(testDate));
     }
 
     List<MinorStatus> getMinorStatusId26() {
@@ -35,3 +36,4 @@ class CaseDataBuilderBaseTest {
     }
 
 }
+

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.reform.sscs.services.mapper;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MajorStatus;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
+
+public class CaseDataBuilderBaseTest {
+
+    static final String TEST_DATE = "2018-05-24T00:00:00+01:00";
+    private static final String TEST_DATE2 = "2017-05-24T00:00:00+01:00";
+
+    private AppealCase appeal;
+
+    @Before
+    public void setUp() {
+        appeal = AppealCase.builder()
+            .appealCaseCaseCodeId("1")
+            .majorStatus(getStatus())
+            .hearing(getHearing())
+            .minorStatus(Collections.singletonList(
+                new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE))))
+            .build();
+    }
+
+    private List<MajorStatus> getStatus() {
+        MajorStatus status = new MajorStatus("", "3", "", ZonedDateTime.parse(TEST_DATE2));
+        return newArrayList(status);
+    }
+
+    private List<Hearing> getHearing() {
+        Hearing hearing = new Hearing("outcome",
+            "venue",
+            "outcomeDate",
+            "notificationDate",
+            "2017-05-24T00:00:00+01:00",
+            "2017-05-24T10:30:00+01:00",
+            "id");
+        return newArrayList(hearing);
+    }
+
+    public AppealCase getAppeal() {
+        return appeal;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
@@ -22,14 +22,14 @@ public class CaseDataBuilderBaseTest {
     public void setUp() {
         appeal = AppealCase.builder()
             .appealCaseCaseCodeId("1")
-            .majorStatus(getStatus())
+            .majorStatus(getAppealReceivedStatus())
             .hearing(getHearing())
             .minorStatus(Collections.singletonList(
                 new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE2))))
             .build();
     }
 
-    public List<MajorStatus> getStatus() {
+    public List<MajorStatus> getAppealReceivedStatus() {
         MajorStatus status = new MajorStatus("", "3", "", ZonedDateTime.parse(TEST_DATE));
         return newArrayList(status);
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
@@ -9,11 +9,11 @@ class CaseDataBuilderBaseTest {
     static final String TEST_DATE2 = "2018-05-24T00:00:00+01:00";
     static final String TEST_DATE = "2017-05-24T00:00:00+01:00";
 
-    MajorStatus buildMajorStatusGivenStatusAndDate(String status, String testDate) {
+    public MajorStatus buildMajorStatusGivenStatusAndDate(String status, String testDate) {
         return new MajorStatus("", status, "", ZonedDateTime.parse(testDate));
     }
 
-    MinorStatus buildMinorStatusGivenIdAndDate(String id, ZonedDateTime date) {
+    public MinorStatus buildMinorStatusGivenIdAndDate(String id, ZonedDateTime date) {
         return new MinorStatus("", id, date);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
@@ -13,8 +13,8 @@ import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 
 public class CaseDataBuilderBaseTest {
 
-    static final String TEST_DATE = "2018-05-24T00:00:00+01:00";
-    private static final String TEST_DATE2 = "2017-05-24T00:00:00+01:00";
+    static final String TEST_DATE2 = "2018-05-24T00:00:00+01:00";
+    static final String TEST_DATE = "2017-05-24T00:00:00+01:00";
 
     private AppealCase appeal;
 
@@ -25,16 +25,16 @@ public class CaseDataBuilderBaseTest {
             .majorStatus(getStatus())
             .hearing(getHearing())
             .minorStatus(Collections.singletonList(
-                new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE))))
+                new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE2))))
             .build();
     }
 
-    private List<MajorStatus> getStatus() {
-        MajorStatus status = new MajorStatus("", "3", "", ZonedDateTime.parse(TEST_DATE2));
+    public List<MajorStatus> getStatus() {
+        MajorStatus status = new MajorStatus("", "3", "", ZonedDateTime.parse(TEST_DATE));
         return newArrayList(status);
     }
 
-    private List<Hearing> getHearing() {
+    public List<Hearing> getHearing() {
         Hearing hearing = new Hearing("outcome",
             "venue",
             "outcomeDate",

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
@@ -10,8 +10,8 @@ import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 
 class CaseDataBuilderBaseTest {
 
-    private static final String TEST_DATE2 = "2018-05-24T00:00:00+01:00";
-    private static final String TEST_DATE = "2017-05-24T00:00:00+01:00";
+    static final String TEST_DATE2 = "2018-05-24T00:00:00+01:00";
+    static final String TEST_DATE = "2017-05-24T00:00:00+01:00";
 
     List<MajorStatus> buildMajorStatusGivenStatuses(GapsEvent... gapsEvents) {
         ArrayList<MajorStatus> majorStatusList = new ArrayList<>(gapsEvents.length);
@@ -30,9 +30,9 @@ class CaseDataBuilderBaseTest {
         return new MajorStatus("", status, "", ZonedDateTime.parse(testDate));
     }
 
-    List<MinorStatus> getMinorStatusId26() {
+    List<MinorStatus> getMinorStatusId26(String testDate) {
         return Collections.singletonList(
-            new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE2)));
+            new MinorStatus("", "26", ZonedDateTime.parse(testDate)));
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
@@ -9,12 +9,12 @@ class CaseDataBuilderBaseTest {
     static final String TEST_DATE2 = "2018-05-24T00:00:00+01:00";
     static final String TEST_DATE = "2017-05-24T00:00:00+01:00";
 
-    public MajorStatus buildMajorStatusGivenStatusAndDate(String status, String testDate) {
+    MajorStatus buildMajorStatusGivenStatusAndDate(String status, String testDate) {
         return new MajorStatus("", status, "", ZonedDateTime.parse(testDate));
     }
 
-    public MinorStatus buildMinorStatusGivenIdAndDate(String id, ZonedDateTime date) {
-        return new MinorStatus("", id, date);
+    MinorStatus buildMinorStatusGivenIdAndDate(String id, String date) {
+        return new MinorStatus("", id, ZonedDateTime.parse(date));
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderBaseTest.java
@@ -6,8 +6,9 @@ import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 
 class CaseDataBuilderBaseTest {
 
-    static final String TEST_DATE2 = "2018-05-24T00:00:00+01:00";
-    static final String TEST_DATE = "2017-05-24T00:00:00+01:00";
+    static final String HEARING_POSTPONED_DATE = "2018-05-24T00:00:00+01:00";
+    static final String MINOR_STATUS_ID_27_DATE = "2018-05-24T00:00:00+01:00";
+    static final String APPEAL_RECEIVED_DATE = "2017-05-24T00:00:00+01:00";
 
     MajorStatus buildMajorStatusGivenStatusAndDate(String status, String testDate) {
         return new MajorStatus("", status, "", ZonedDateTime.parse(testDate));

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.sscs.services.mapper.CaseDataBuilder.NO;
 
@@ -95,4 +97,12 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
         assertThat(hearing.getValue().getVenue().getName(), is("name"));
     }
 
+    @Test
+    public void shouldCallAdjournedEventsBuilder() {
+        AppealCase appealCase = AppealCase.builder().build();
+
+        caseDataBuilder.buildEvent(appealCase);
+
+        verify(caseDataEventBuilder, times(1)).buildAdjournedEvents(appealCase);
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -46,7 +46,10 @@ public class CaseDataBuilderTest {
             .appealCaseCaseCodeId("1")
             .majorStatus(getStatus())
             .hearing(getHearing())
-            .minorStatus(Collections.singletonList(MinorStatus.builder().build()))
+            .minorStatus(Collections.singletonList(MinorStatus.builder()
+                .statusId("26")
+                .dateSet(ZonedDateTime.parse("2017-05-24T00:00:00+01:00"))
+                .build()))
             .build();
     }
 
@@ -72,7 +75,13 @@ public class CaseDataBuilderTest {
     @Test
     public void shouldBuildAPostponedEventGivenMinorStatus() {
         List<Events> events = caseDataBuilder.buildEvent(appeal);
-        assertTrue(events.get(0).getValue().getType().equals(GapsEvent.HEARING_POSTPONED.getType()));
+        assertTrue("event is not of type Postponed",
+            events.get(0).getValue().getType().equals(GapsEvent.HEARING_POSTPONED.getType()));
+
+        ZonedDateTime actualDateEvent = ZonedDateTime.parse(events.get(0).getValue().getDate());
+        ZonedDateTime expectedDateEvent = ZonedDateTime.parse("2017-05-24T00:00:00+01:00");
+        assertTrue("event date does not matches minor status date_set field",
+            actualDateEvent.isEqual(expectedDateEvent));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -2,21 +2,27 @@ package uk.gov.hmcts.reform.sscs.services.mapper;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.sscs.services.mapper.CaseDataBuilder.NO;
 
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.sscs.models.GapsEvent;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MajorStatus;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 import uk.gov.hmcts.reform.sscs.models.refdata.VenueDetails;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.BenefitType;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Hearing;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.subscriptions.Subscriptions;
 import uk.gov.hmcts.reform.sscs.services.refdata.ReferenceDataService;
@@ -40,6 +46,7 @@ public class CaseDataBuilderTest {
             .appealCaseCaseCodeId("1")
             .majorStatus(getStatus())
             .hearing(getHearing())
+            .minorStatus(Collections.singletonList(MinorStatus.builder().build()))
             .build();
     }
 
@@ -60,6 +67,12 @@ public class CaseDataBuilderTest {
                 appealTime,
                 "id");
         return newArrayList(hearing);
+    }
+
+    @Test
+    public void shouldBuildAPostponedEventGivenMinorStatus() {
+        List<Events> events = caseDataBuilder.buildEvent(appeal);
+        assertTrue(events.get(0).getValue().getType().equals(GapsEvent.HEARING_POSTPONED.getType()));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -38,7 +38,7 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
             .appealCaseCaseCodeId("1")
             .majorStatus(buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED))
             .hearing(getHearing())
-            .minorStatus(super.getMinorStatusId26())
+            .minorStatus(super.getMinorStatusId26(TEST_DATE2))
             .build();
         caseDataBuilder = new CaseDataBuilder(refDataService, caseDataEventBuilder);
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.sscs.services.mapper.CaseDataBuilder.NO;
 
-import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
@@ -43,7 +42,7 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
             ))
             .hearing(getHearing())
             .minorStatus(Collections.singletonList(
-                super.buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
+                super.buildMinorStatusGivenIdAndDate("26", TEST_DATE2)))
             .build();
         caseDataBuilder = new CaseDataBuilder(refDataService, caseDataEventBuilder);
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -9,16 +9,12 @@ import static uk.gov.hmcts.reform.sscs.services.mapper.CaseDataBuilder.NO;
 
 import java.util.List;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import uk.gov.hmcts.reform.sscs.models.GapsEvent;
 import uk.gov.hmcts.reform.sscs.models.refdata.VenueDetails;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.BenefitType;
-import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Event;
-import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Hearing;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.subscriptions.Subscriptions;
 import uk.gov.hmcts.reform.sscs.services.refdata.ReferenceDataService;
@@ -73,29 +69,6 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
         assertThat(hearing.getValue().getHearingDate(), is("2017-05-24"));
         assertThat(hearing.getValue().getTime(), is("10:30:00"));
         assertThat(hearing.getValue().getVenue().getName(), is("name"));
-    }
-
-    //fixme move to integration tests
-    @Test
-    @Ignore
-    public void whenBuildEventMethodIsCalledThenItReturnsAnEventListSortedByDateInDescOrder() {
-        List<Events> events = caseDataBuilder.buildEvent(super.getAppeal());
-        assertTrue("events size only has 1 element", events.size() > 1);
-        Event actualMostRecentEvent = events.get(0).getValue();
-        assertTrue("expected most recent Event is wrong",
-            actualMostRecentEvent.getType().equals(GapsEvent.HEARING_POSTPONED.getType()));
-    }
-
-    @Test
-    @Ignore
-    public void givenAFewMinorStatuesShouldCreatePostponedEventFromTheLatestMinorStatus() {
-
-    }
-
-    @Test
-    @Ignore
-    public void givenAMinorStatusShouldCreatePostponedEventIfItDoesNotExistAlready() {
-
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.sscs.services.mapper;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -8,9 +7,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.sscs.services.mapper.CaseDataBuilder.NO;
 
-import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
-import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -19,9 +15,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.sscs.models.GapsEvent;
-import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
-import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MajorStatus;
-import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 import uk.gov.hmcts.reform.sscs.models.refdata.VenueDetails;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.BenefitType;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Event;
@@ -31,51 +24,26 @@ import uk.gov.hmcts.reform.sscs.models.serialize.ccd.subscriptions.Subscriptions
 import uk.gov.hmcts.reform.sscs.services.refdata.ReferenceDataService;
 
 @RunWith(MockitoJUnitRunner.class)
-public class CaseDataBuilderTest {
+public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
 
-    private static final String TEST_DATE = "2018-05-24T00:00:00+01:00";
-    private static final String TEST_DATE2 = "2017-05-24T00:00:00+01:00";
     @Mock
     private ReferenceDataService refDataService;
-    private AppealCase appeal;
+    @Mock
+    private CaseDataEventBuilder caseDataEventBuilder;
     private CaseDataBuilder caseDataBuilder;
-    private List<Events> events;
 
+    @Override
     @Before
     public void setUp() {
-        CaseDataEventBuilder caseDataEventBuilder = new CaseDataEventBuilder();
+        super.setUp();
         caseDataBuilder = new CaseDataBuilder(refDataService, caseDataEventBuilder);
-        appeal = AppealCase.builder()
-            .appealCaseCaseCodeId("1")
-            .majorStatus(getStatus())
-            .hearing(getHearing())
-            .minorStatus(Collections.singletonList(
-                new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE))))
-            .build();
-    }
-
-    private List<MajorStatus> getStatus() {
-        MajorStatus status = new MajorStatus("", "3", "", ZonedDateTime.parse(TEST_DATE2));
-        return newArrayList(status);
-    }
-
-    private List<uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing> getHearing() {
-        uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing hearing =
-            new uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing("outcome",
-                "venue",
-                "outcomeDate",
-                "notificationDate",
-                "2017-05-24T00:00:00+01:00",
-                "2017-05-24T10:30:00+01:00",
-                "id");
-        return newArrayList(hearing);
     }
 
     @Test
     public void shouldBuildBenefitTypeGivenAppealCase() {
         when(refDataService.getBenefitType("1")).thenReturn("A");
 
-        BenefitType benefitType = caseDataBuilder.buildBenefitType(appeal);
+        BenefitType benefitType = caseDataBuilder.buildBenefitType(super.getAppeal());
         assertThat(benefitType.getCode(), is("A"));
     }
 
@@ -97,7 +65,7 @@ public class CaseDataBuilderTest {
 
         when(refDataService.getVenueDetails("venue")).thenReturn(venue);
 
-        List<Hearing> hearings = caseDataBuilder.buildHearings(appeal);
+        List<Hearing> hearings = caseDataBuilder.buildHearings(super.getAppeal());
 
         Hearing hearing = hearings.get(0);
 
@@ -107,27 +75,16 @@ public class CaseDataBuilderTest {
         assertThat(hearing.getValue().getVenue().getName(), is("name"));
     }
 
-    //fixme Move this test to the integrating test because it is testing other dependencies.
+    //fixme move to integration tests
     @Test
-    public void givenMinorStatusIsPresentInTheXmlCaseWhenBuildEventIsCalledThenAPostponedEventIsCreated() {
-        events = caseDataBuilder.buildEvent(appeal);
-        assertTrue("event is not of type Postponed",
-            events.get(0).getValue().getType().equals(GapsEvent.HEARING_POSTPONED.getType()));
-
-        LocalDateTime actualDateEvent = LocalDateTime.parse(events.get(0).getValue().getDate());
-        assertTrue("event date does not matches minor status date_set field",
-            actualDateEvent.isEqual(ZonedDateTime.parse(TEST_DATE).toLocalDateTime()));
-    }
-
-    @Test
+    @Ignore
     public void whenBuildEventMethodIsCalledThenItReturnsAnEventListSortedByDateInDescOrder() {
-        events = caseDataBuilder.buildEvent(appeal);
+        List<Events> events = caseDataBuilder.buildEvent(super.getAppeal());
         assertTrue("events size only has 1 element", events.size() > 1);
         Event actualMostRecentEvent = events.get(0).getValue();
         assertTrue("expected most recent Event is wrong",
             actualMostRecentEvent.getType().equals(GapsEvent.HEARING_POSTPONED.getType()));
     }
-
 
     @Test
     @Ignore

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.sscs.services.mapper;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -76,7 +77,7 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
         assertNotNull("SupporterSubscription is null", subscriptions.getSupporterSubscription());
         String appealNumber = subscriptions.getAppellantSubscription().getTya();
         assertTrue("appealNumber is empty", !"".equals(appealNumber));
-        assertTrue("appealNumber length is not 10 digits", appealNumber.length() == 10);
+        assertEquals("appealNumber length is not 10 digits", 10, appealNumber.length());
     }
 
     @Test
@@ -104,5 +105,16 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
         caseDataBuilder.buildEvent(appealCase);
 
         verify(caseDataEventBuilder, times(1)).buildAdjournedEvents(appealCase);
+    }
+
+    @Test
+    public void givenHearingInDeltaWhenBuildingHearingThenHearingIdIsBuilt() {
+        when(refDataService.getVenueDetails("venue")).thenReturn(VenueDetails.builder()
+            .venName("name")
+            .build());
+
+        List<Hearing> hearingList = caseDataBuilder.buildHearings(appeal);
+
+        assertEquals("id", hearingList.get(0).getValue().getHearingId());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -40,11 +40,11 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
         appeal = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .majorStatus(Collections.singletonList(
-                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), APPEAL_RECEIVED_DATE)
             ))
             .hearing(getHearing())
             .minorStatus(Collections.singletonList(
-                super.buildMinorStatusGivenIdAndDate("26", TEST_DATE2)))
+                super.buildMinorStatusGivenIdAndDate("26", HEARING_POSTPONED_DATE)))
             .build();
         caseDataBuilder = new CaseDataBuilder(refDataService, caseDataEventBuilder);
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -8,6 +8,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.sscs.services.mapper.CaseDataBuilder.NO;
 
+import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,7 +40,8 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
             .appealCaseCaseCodeId("1")
             .majorStatus(buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED))
             .hearing(getHearing())
-            .minorStatus(super.getMinorStatusId26(TEST_DATE2))
+            .minorStatus(Collections.singletonList(
+                super.getMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
             .build();
         caseDataBuilder = new CaseDataBuilder(refDataService, caseDataEventBuilder);
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.sscs.services.mapper.CaseDataBuilder.NO;
 
+import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.List;
@@ -47,11 +48,10 @@ public class CaseDataBuilderTest {
             .appealCaseCaseCodeId("1")
             .majorStatus(getStatus())
             .hearing(getHearing())
-            .minorStatus(Collections.singletonList(MinorStatus.builder()
-                .statusId("26")
-                .dateSet(ZonedDateTime.parse(TEST_DATE))
-                .build()))
+            .minorStatus(Collections.singletonList(
+                new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE))))
             .build();
+
     }
 
     private List<MajorStatus> getStatus() {
@@ -116,9 +116,9 @@ public class CaseDataBuilderTest {
         assertTrue("event is not of type Postponed",
             events.get(0).getValue().getType().equals(GapsEvent.HEARING_POSTPONED.getType()));
 
-        ZonedDateTime actualDateEvent = ZonedDateTime.parse(events.get(0).getValue().getDate());
+        LocalDateTime actualDateEvent = LocalDateTime.parse(events.get(0).getValue().getDate());
         assertTrue("event date does not matches minor status date_set field",
-            actualDateEvent.isEqual(ZonedDateTime.parse(TEST_DATE)));
+            actualDateEvent.isEqual(ZonedDateTime.parse(TEST_DATE).toLocalDateTime()));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.sscs.services.mapper;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -13,6 +14,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import uk.gov.hmcts.reform.sscs.models.GapsEvent;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
 import uk.gov.hmcts.reform.sscs.models.refdata.VenueDetails;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.BenefitType;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Hearing;
@@ -27,19 +30,36 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
     @Mock
     private CaseDataEventBuilder caseDataEventBuilder;
     private CaseDataBuilder caseDataBuilder;
+    private AppealCase appeal;
 
-    @Override
     @Before
     public void setUp() {
-        super.setUp();
+        appeal = AppealCase.builder()
+            .appealCaseCaseCodeId("1")
+            .majorStatus(buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED))
+            .hearing(getHearing())
+            .minorStatus(super.getMinorStatusId26())
+            .build();
         caseDataBuilder = new CaseDataBuilder(refDataService, caseDataEventBuilder);
+    }
+
+    public List<uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing> getHearing() {
+        uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing hearing =
+            new uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing("outcome",
+                "venue",
+                "outcomeDate",
+                "notificationDate",
+                "2017-05-24T00:00:00+01:00",
+                "2017-05-24T10:30:00+01:00",
+                "id");
+        return newArrayList(hearing);
     }
 
     @Test
     public void shouldBuildBenefitTypeGivenAppealCase() {
         when(refDataService.getBenefitType("1")).thenReturn("A");
 
-        BenefitType benefitType = caseDataBuilder.buildBenefitType(super.getAppeal());
+        BenefitType benefitType = caseDataBuilder.buildBenefitType(appeal);
         assertThat(benefitType.getCode(), is("A"));
     }
 
@@ -61,7 +81,7 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
 
         when(refDataService.getVenueDetails("venue")).thenReturn(venue);
 
-        List<Hearing> hearings = caseDataBuilder.buildHearings(super.getAppeal());
+        List<Hearing> hearings = caseDataBuilder.buildHearings(appeal);
 
         Hearing hearing = hearings.get(0);
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -27,7 +27,7 @@ import uk.gov.hmcts.reform.sscs.models.serialize.ccd.subscriptions.Subscriptions
 import uk.gov.hmcts.reform.sscs.services.refdata.ReferenceDataService;
 
 @RunWith(MockitoJUnitRunner.class)
-public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
+public class CaseDataBuilderTest extends CaseDataBuilderBase {
 
     @Mock
     private ReferenceDataService refDataService;

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -43,7 +43,8 @@ public class CaseDataBuilderTest {
 
     @Before
     public void setUp() {
-        caseDataBuilder = new CaseDataBuilder(refDataService);
+        CaseDataEventBuilder caseDataEventBuilder = new CaseDataEventBuilder();
+        caseDataBuilder = new CaseDataBuilder(refDataService, caseDataEventBuilder);
         appeal = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .majorStatus(getStatus())
@@ -51,7 +52,6 @@ public class CaseDataBuilderTest {
             .minorStatus(Collections.singletonList(
                 new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE))))
             .build();
-
     }
 
     private List<MajorStatus> getStatus() {
@@ -107,9 +107,7 @@ public class CaseDataBuilderTest {
         assertThat(hearing.getValue().getVenue().getName(), is("name"));
     }
 
-    /**
-     * Building Event test coverage.
-     */
+    //fixme Move this test to the integrating test because it is testing other dependencies.
     @Test
     public void givenMinorStatusIsPresentInTheXmlCaseWhenBuildEventIsCalledThenAPostponedEventIsCreated() {
         events = caseDataBuilder.buildEvent(appeal);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -38,10 +38,12 @@ public class CaseDataBuilderTest extends CaseDataBuilderBaseTest {
     public void setUp() {
         appeal = AppealCase.builder()
             .appealCaseCaseCodeId("1")
-            .majorStatus(buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED))
+            .majorStatus(Collections.singletonList(
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
+            ))
             .hearing(getHearing())
             .minorStatus(Collections.singletonList(
-                super.getMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
+                super.buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
             .build();
         caseDataBuilder = new CaseDataBuilder(refDataService, caseDataEventBuilder);
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -40,7 +40,7 @@ import uk.gov.hmcts.reform.sscs.services.ccd.SearchCcdService;
 import uk.gov.hmcts.reform.sscs.services.idam.IdamService;
 
 @RunWith(JUnitParamsRunner.class)
-public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
+public class CaseDataEventBuilderTest extends CaseDataBuilderBase {
 
     private static final String SESSION_DATE = "2017-05-23T00:00:00+01:00";
     private static final String LOCAL_SESSION_DATE = "2017-05-23T00:00:00";

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -1,13 +1,16 @@
 package uk.gov.hmcts.reform.sscs.services.mapper;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.List;
 import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.models.GapsEvent;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Event;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
 
 public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
@@ -20,7 +23,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
         AppealCase appealCaseWithMinorStatusId26 = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .majorStatus(super.buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED))
-            .minorStatus(super.getMinorStatusId26())
+            .minorStatus(super.getMinorStatusId26(TEST_DATE2))
             .build();
 
         events = caseDataEventBuilder.buildPostponedEvent(
@@ -37,16 +40,42 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
     }
 
     @Test
-    public void givenAPostponedEventIsAlreadyPresentThenAnotherPostponedWithSameDateIsNotCreated() {
-        AppealCase appealWithPostponedEventAndMinorStatus = AppealCase.builder()
+    public void givenAnExistingPostponedEventAndMinorStatusId26WithSameDatesThenNoNewPostponedEventIsCreated() {
+        AppealCase appealWithPostponedAndMinorStatusWithSameDated = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .majorStatus(super.buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED, GapsEvent.HEARING_POSTPONED))
-            .minorStatus(super.getMinorStatusId26())
+            .minorStatus(super.getMinorStatusId26(TEST_DATE2))
             .build();
 
-        events = caseDataEventBuilder.buildPostponedEvent(appealWithPostponedEventAndMinorStatus);
+        events = caseDataEventBuilder.buildPostponedEvent(appealWithPostponedAndMinorStatusWithSameDated);
 
         assertTrue("Postponed event should not be created here", events.isEmpty());
+    }
+
+    @Test
+    public void givenAnExistingPostponedEventAndMinorStatusId26WithDifferentDatesThenANewPostponedEventIsCreated() {
+        AppealCase appealWithPostponedAndMinorStatusWithDifferentDates = AppealCase.builder()
+            .appealCaseCaseCodeId("1")
+            .majorStatus(super.buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED, GapsEvent.HEARING_POSTPONED))
+            .minorStatus(super.getMinorStatusId26(TEST_DATE))
+            .build();
+
+        events = caseDataEventBuilder.buildPostponedEvent(appealWithPostponedAndMinorStatusWithDifferentDates);
+
+        assertTrue("Postponed event should be created here", events.size() == 1);
+
+        Event actualEvent = events.get(0).getValue();
+        assertTrue("event is not Postponed", actualEvent.getType().equals(
+            GapsEvent.HEARING_POSTPONED.getType()));
+
+        String existingPostponedDate = ZonedDateTime.parse(TEST_DATE2).toLocalDateTime().toString();
+        assertFalse("new postponed date cannot be equal to the existing postpone date",
+            actualEvent.getDate().equals(existingPostponedDate));
+
+        String expectedPostponedDate = appealWithPostponedAndMinorStatusWithDifferentDates
+            .getMinorStatus().get(0).getDateSet().toLocalDateTime().toString();
+        assertTrue("new postponed event date is not equal to the minor status date",
+            actualEvent.getDate().equals(expectedPostponedDate));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -151,6 +151,13 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
                 buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
             .build();
 
+        events = caseDataEventBuilder.buildPostponedEvent(appealWithTwoMinorStatusesAndNoPostponed);
+
+        assertTrue("Only One new postponed event should be created here", events.size() == 1);
+        LocalDateTime actualEvenDate = LocalDateTime.parse(events.get(0).getValue().getDate());
+        LocalDateTime expectedEventDate = ZonedDateTime.parse(TEST_DATE).toLocalDateTime();
+        assertTrue("", actualEvenDate.equals(expectedEventDate));
+
 
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -288,9 +288,9 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
 
         events = caseDataEventBuilder.buildPostponedEvent(appealWithMinorStatusId27AndPostponedGrantedY);
 
-        assertTrue("Events size expected is 1 here", events.size() == 1);
-        assertTrue("Postponed event is expected here",
-            events.get(0).getValue().getType().equals(GapsEvent.HEARING_POSTPONED.getType()));
+        assertEquals("Events size expected is 1 here", 1, events.size());
+        assertEquals("Postponed event is expected here", events.get(0).getValue().getType(),
+            GapsEvent.HEARING_POSTPONED.getType());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.reform.sscs.services.mapper;
+
+import static org.junit.Assert.assertTrue;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.junit.Ignore;
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscs.models.GapsEvent;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
+
+public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
+
+    @Test
+    public void givenMinorStatusIsPresentInTheXmlCaseWhenBuildPostponedEventIsCalledThenAPostponedEventIsCreated() {
+        CaseDataEventBuilder caseDataEventBuilder = new CaseDataEventBuilder();
+        List<Events> events = caseDataEventBuilder.buildPostponedEvent(super.getAppeal());
+        assertTrue("event is not of type Postponed",
+            events.get(0).getValue().getType().equals(GapsEvent.HEARING_POSTPONED.getType()));
+
+        LocalDateTime actualDateEvent = LocalDateTime.parse(events.get(0).getValue().getDate());
+        assertTrue("event date does not matches minor status date_set field",
+            actualDateEvent.isEqual(ZonedDateTime.parse(TEST_DATE).toLocalDateTime()));
+    }
+
+    @Test
+    @Ignore
+    public void whenMinorStatusIsNullThenPostponedEventIsNotCreated() {
+
+    }
+
+    @Test
+    @Ignore
+    public void whenMinorStatusIsEmptyThenPostponedEventIsNotCreated() {
+
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -438,7 +437,6 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBase {
     Then two postponed events should be created
      */
     @Test
-    @Ignore
     public void givenScenario5Then2PostponedEventsAreCreated() throws IOException {
         AppealCase appeal = AppealCase.builder()
             .appealCaseCaseCodeId("1")
@@ -483,6 +481,20 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBase {
                 anyListOf(uk.gov.hmcts.reform.sscs.models.serialize.ccd.Hearing.class));
 
         assertEquals("2 postponed events expected here", 2, events.size());
+
+        LocalDateTime expectedDateOfPostponedComingFromMajorStatus = ZonedDateTime.parse(RESPONSE_RECEIVED_DATE)
+            .toLocalDateTime();
+        LocalDateTime actualDateOfPostponedComingFromMajorStatus = LocalDateTime.parse(
+            events.get(0).getValue().getDate());
+        assertEquals("event date must be equal to major status 18 date",
+            expectedDateOfPostponedComingFromMajorStatus, actualDateOfPostponedComingFromMajorStatus);
+
+        LocalDateTime expectedDateOfPostponedComingFromMinorStatus = ZonedDateTime.parse(MINOR_STATUS_ID_27_DATE)
+            .toLocalDateTime();
+        LocalDateTime actualDateOfPostponedComingFromMinorStatus = LocalDateTime.parse(
+            events.get(1).getValue().getDate());
+        assertEquals("event date must be equal to major status 18 date",
+            expectedDateOfPostponedComingFromMinorStatus, actualDateOfPostponedComingFromMinorStatus);
     }
 
     /*
@@ -491,7 +503,13 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBase {
         And postponed_granted Yes
         And no hearing element present in Delta
         And there is a hearingId matching to the postponementHearingId in the existing case in CCD
-        Then create a Postponed event with major status date_set
+        Then 2 Postponed events with major status date_set are created
 
+     */
+
+    /*
+        scenario7:
+        given no major status id 18
+        what happens
      */
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -120,14 +120,22 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
 
         events = caseDataEventBuilder.buildPostponedEvent(appealWithTwoMinorStatusesAndNoPostponed);
 
-        System.out.println(events);
         assertTrue("Two new postponed event should be created here", events.size() == 2);
-
+        LocalDateTime actualEvenDate = LocalDateTime.parse(events.get(0).getValue().getDate());
+        LocalDateTime expectedEventDate = ZonedDateTime.parse(TEST_DATE).toLocalDateTime();
+        assertTrue("", actualEvenDate.equals(expectedEventDate));
     }
 
     @Test
-    @Ignore
     public void givenTwoMinorStatusAndOneExistingPostponedEventArePresentThenOnlyOneNewPostponedEventIsCreated() {
+        AppealCase appealWithTwoMinorStatusesAndNoPostponed = AppealCase.builder()
+            .appealCaseCaseCodeId("1")
+            .majorStatus(super.buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED, GapsEvent.HEARING_POSTPONED))
+            .minorStatus(Arrays.asList(
+                getMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE)),
+                getMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
+            .build();
+
 
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -1,27 +1,75 @@
 package uk.gov.hmcts.reform.sscs.services.mapper;
 
+import static com.google.common.collect.Lists.newArrayList;
 import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.models.GapsEvent;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MajorStatus;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
 
 public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
 
+    private final CaseDataEventBuilder caseDataEventBuilder = new CaseDataEventBuilder();
+    private List<Events> events;
+
     @Test
-    public void givenMinorStatusIsPresentInTheXmlCaseWhenBuildPostponedEventIsCalledThenAPostponedEventIsCreated() {
-        CaseDataEventBuilder caseDataEventBuilder = new CaseDataEventBuilder();
-        List<Events> events = caseDataEventBuilder.buildPostponedEvent(super.getAppeal());
+    public void givenMinorStatusWithId26ThenAPostponedEventIsCreated() {
+        AppealCase appealCaseWithMinorStatusId26AndSomeMajorStatuses = super.getAppeal();
+
+        events = caseDataEventBuilder.buildPostponedEvent(
+            appealCaseWithMinorStatusId26AndSomeMajorStatuses);
+
         assertTrue("event is not of type Postponed",
             events.get(0).getValue().getType().equals(GapsEvent.HEARING_POSTPONED.getType()));
 
         LocalDateTime actualDateEvent = LocalDateTime.parse(events.get(0).getValue().getDate());
-        assertTrue("event date does not matches minor status date_set field",
-            actualDateEvent.isEqual(ZonedDateTime.parse(TEST_DATE).toLocalDateTime()));
+        assertTrue("event date does not match minor status date_set field",
+            actualDateEvent.isEqual(ZonedDateTime.parse(TEST_DATE2).toLocalDateTime()));
+    }
+
+    @Test
+    @Ignore
+    public void givenAPostponedEventIsAlreadyPresentThenAnotherPostponedWithSameDateIsNotCreated() {
+        AppealCase appealWithPostponedAndMinorStatus = AppealCase.builder()
+            .appealCaseCaseCodeId("1")
+            .majorStatus(getStatus())
+            .hearing(super.getHearing())
+            .minorStatus(getMinorStatus())
+            .build();
+
+        events = caseDataEventBuilder.buildPostponedEvent(appealWithPostponedAndMinorStatus);
+
+        List<Events> postponedEvents = events.stream()
+            .filter(event -> event.getValue().getType().equals(GapsEvent.HEARING_POSTPONED.getType()))
+            .collect(Collectors.toList());
+
+        assertTrue("Same Postponed event created", postponedEvents.size() == 1);
+
+        String postponedDate = postponedEvents.get(0).getValue().getDate();
+        ZonedDateTime minorStatusId26Date = appealWithPostponedAndMinorStatus.getMinorStatus().get(0).getDateSet();
+        assertTrue(postponedDate.equals(minorStatusId26Date));
+    }
+
+    private List<MinorStatus> getMinorStatus() {
+        return Collections.singletonList(
+            new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE2)));
+    }
+
+    public List<MajorStatus> getStatus() {
+        MajorStatus appealReceivedStatus = new MajorStatus("", "3", "",
+            ZonedDateTime.parse(TEST_DATE));
+        MajorStatus postponedStatus = new MajorStatus("", GapsEvent.HEARING_POSTPONED.getStatus(),
+            "", ZonedDateTime.parse(TEST_DATE2));
+        return newArrayList(appealReceivedStatus, postponedStatus);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -388,7 +388,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBase {
 
     /*
         scenario4:
-        Given major status with id 18
+        Given major status with id 18 is the current appeal status
         And postponed_granted Yes
         And no hearing element present in Delta
         And there is a hearingId matching to the postponementHearingId in the existing case in CCD

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -189,6 +189,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
     /*
         scenario1:
         Given minor status with id 27
+        And two hearing objects
         And two postponed request elements with the granted field to 'Y'
         And none of them matching the hearing id field
         Then NO postponed element is created
@@ -202,7 +203,10 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
             ))
             .minorStatus(Collections.singletonList(
                 super.buildMinorStatusGivenIdAndDate("27", MINOR_STATUS_ID_27_DATE)))
-            .hearing(Collections.singletonList(Hearing.builder().hearingId("1").build()))
+            .hearing(Arrays.asList(
+                Hearing.builder().hearingId("1").build(),
+                Hearing.builder().hearingId("2").build()
+            ))
             .postponementRequests(Arrays.asList(
                 new PostponementRequests(
                     "Y", "", null, null),
@@ -219,6 +223,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
     /*
         scenario2:
         Given minor status with id 27
+        And two hearing objects
         And two postponed request elements with the granted field to 'Y'
         And one of them matching the hearing id field
         Then one postponed element is created
@@ -232,7 +237,10 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
             ))
             .minorStatus(Collections.singletonList(
                 super.buildMinorStatusGivenIdAndDate("27", MINOR_STATUS_ID_27_DATE)))
-            .hearing(Collections.singletonList(Hearing.builder().hearingId("1").build()))
+            .hearing(Arrays.asList(
+                Hearing.builder().hearingId("1").build(),
+                Hearing.builder().hearingId("2").build()
+            ))
             .postponementRequests(Arrays.asList(
                 new PostponementRequests(
                     "Y", "", null, null),

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.hmcts.reform.sscs.models.GapsEvent;
@@ -381,11 +382,13 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
         scenario2:
         Given minor status with id 27
         And two postponed request elements with the granted field to 'Y'
-        And one of them matching the hearing id field
-        And the hearing object is not present in the Delta
-        Then one postponed element is created
+        And the hearing is not present in the Delta
+        Then we search for the hearing_id in CCD
+        And if it matches with any of the postponed element
+        Then we create one postponed event
      */
     @Test
+    @Ignore
     public void givenScenario3ThenPostponedEventIsCreated() {
 
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -1,18 +1,13 @@
 package uk.gov.hmcts.reform.sscs.services.mapper;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
-import java.util.Collections;
 import java.util.List;
 import org.junit.Ignore;
 import org.junit.Test;
 import uk.gov.hmcts.reform.sscs.models.GapsEvent;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
-import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MajorStatus;
-import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
 
 public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
@@ -24,8 +19,8 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
     public void givenMinorStatusWithId26ThenAPostponedEventIsCreated() {
         AppealCase appealCaseWithMinorStatusId26 = AppealCase.builder()
             .appealCaseCaseCodeId("1")
-            .majorStatus(super.getAppealReceivedStatus())
-            .minorStatus(getMinorStatusId26())
+            .majorStatus(super.buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED))
+            .minorStatus(super.getMinorStatusId26())
             .build();
 
         events = caseDataEventBuilder.buildPostponedEvent(
@@ -45,26 +40,13 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
     public void givenAPostponedEventIsAlreadyPresentThenAnotherPostponedWithSameDateIsNotCreated() {
         AppealCase appealWithPostponedEventAndMinorStatus = AppealCase.builder()
             .appealCaseCaseCodeId("1")
-            .majorStatus(getPostponedAndOtherMajorStatuses())
-            .minorStatus(getMinorStatusId26())
+            .majorStatus(super.buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED, GapsEvent.HEARING_POSTPONED))
+            .minorStatus(super.getMinorStatusId26())
             .build();
 
         events = caseDataEventBuilder.buildPostponedEvent(appealWithPostponedEventAndMinorStatus);
 
         assertTrue("Postponed event should not be created here", events.isEmpty());
-    }
-
-    private List<MinorStatus> getMinorStatusId26() {
-        return Collections.singletonList(
-            new MinorStatus("", "26", ZonedDateTime.parse(TEST_DATE2)));
-    }
-
-    private List<MajorStatus> getPostponedAndOtherMajorStatuses() {
-        MajorStatus appealReceivedStatus = new MajorStatus("", GapsEvent.APPEAL_RECEIVED.getStatus(),
-            "", ZonedDateTime.parse(TEST_DATE));
-        MajorStatus postponedStatus = new MajorStatus("", GapsEvent.HEARING_POSTPONED.getStatus(),
-            "", ZonedDateTime.parse(TEST_DATE2));
-        return newArrayList(appealReceivedStatus, postponedStatus);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -416,6 +416,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBase {
         when(postponedEventInferredFromCcd.matchToHearingId(eq(appeal.getPostponementRequests()),
             anyListOf(uk.gov.hmcts.reform.sscs.models.serialize.ccd.Hearing.class))).thenReturn(true);
 
+
         events = caseDataEventBuilder.buildPostponedEvent(appeal);
 
         verify(searchCcdService, times(1)).findCaseByCaseRef(anyString(),
@@ -446,6 +447,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBase {
                 super.buildMajorStatusGivenStatusAndDate(GapsEvent.RESPONSE_RECEIVED.getStatus(),
                     RESPONSE_RECEIVED_DATE)
             ))
+            .hearing(null)
             .minorStatus(Collections.singletonList(
                 super.buildMinorStatusGivenIdAndDate("27", MINOR_STATUS_ID_27_DATE)))
             .postponementRequests(Arrays.asList(
@@ -455,9 +457,6 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBase {
                     "Y", "", null, null)
             ))
             .build();
-
-        when(postponedEventInferredFromDelta.matchToHearingId(eq(appeal.getPostponementRequests()),
-            anyListOf(Hearing.class))).thenReturn(false);
 
         when(searchCcdService.findCaseByCaseRef(anyString(), Matchers.any(IdamTokens.class)))
             .thenReturn(Collections.singletonList(CaseDetailsUtils.getCaseDetails(CASE_DETAILS_WITH_HEARINGS_JSON)))
@@ -469,9 +468,6 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBase {
             .thenReturn(true);
 
         events = caseDataEventBuilder.buildPostponedEvent(appeal);
-
-        verify(postponedEventInferredFromDelta, times(1))
-            .matchToHearingId(anyListOf(PostponementRequests.class), anyListOf(Hearing.class));
 
         verify(searchCcdService, times(2)).findCaseByCaseRef(anyString(),
             Matchers.any(IdamTokens.class));
@@ -497,19 +493,4 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBase {
             expectedDateOfPostponedComingFromMinorStatus, actualDateOfPostponedComingFromMinorStatus);
     }
 
-    /*
-        Scenario6:
-        Given two major status with id 18
-        And postponed_granted Yes
-        And no hearing element present in Delta
-        And there is a hearingId matching to the postponementHearingId in the existing case in CCD
-        Then 2 Postponed events with major status date_set are created
-
-     */
-
-    /*
-        scenario7:
-        given no major status id 18
-        what happens
-     */
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -14,15 +14,16 @@ import java.util.Collections;
 import java.util.List;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.hmcts.reform.sscs.models.GapsEvent;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.PostponementRequests;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Event;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
-
 
 @RunWith(JUnitParamsRunner.class)
 public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
@@ -268,6 +269,53 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
         List<Events> events = caseDataEventBuilder.buildAdjournedEvents(appealCase);
 
         assertThat(events.size(), equalTo(1));
+    }
 
+    @Test
+    public void givenMinorStatusId27AndPostponedGrantedYesThenNewPostponedIsCreated() {
+        AppealCase appealWithMinorStatusId27AndPostponedGrantedY = AppealCase.builder()
+            .appealCaseCaseCodeId("1")
+            .majorStatus(Collections.singletonList(
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
+            ))
+            .minorStatus(Collections.singletonList(
+                super.buildMinorStatusGivenIdAndDate("27", TEST_DATE2)))
+            .postponementRequests(Collections.singletonList(
+                new PostponementRequests(
+                    "Y", null, null, null)
+            ))
+            .build();
+
+        events = caseDataEventBuilder.buildPostponedEvent(appealWithMinorStatusId27AndPostponedGrantedY);
+
+        assertTrue("Events size expected is 1 here", events.size() == 1);
+        assertTrue("Postponed event is expected here",
+            events.get(0).getValue().getType().equals(GapsEvent.HEARING_POSTPONED.getType()));
+    }
+
+    @Test
+    public void givenMinorStatusId27AndPostponedGrantedNoThenNoPostponedIsCreated() {
+        AppealCase appealWithMinorStatusId27AndPostponedGrantedY = AppealCase.builder()
+            .appealCaseCaseCodeId("1")
+            .majorStatus(Collections.singletonList(
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
+            ))
+            .minorStatus(Collections.singletonList(
+                super.buildMinorStatusGivenIdAndDate("27", TEST_DATE2)))
+            .postponementRequests(Collections.singletonList(
+                new PostponementRequests(
+                    "N", null, null, null)
+            ))
+            .build();
+
+        events = caseDataEventBuilder.buildPostponedEvent(appealWithMinorStatusId27AndPostponedGrantedY);
+
+        assertTrue("Events size expected is empty here", events.isEmpty());
+    }
+
+    @Test
+    @Ignore
+    public void givenMinorStatusId27AndTwoPostponedGrantedYesThen() {
+        //fixme clarify this scenario with Josh
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -256,4 +256,19 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
 
         assertThat(events, equalTo(Collections.EMPTY_LIST));
     }
+
+    @Test
+    public void shouldIgnoreHearingsWithNoOutComeIdWhenCreatingAdjournedEvents() {
+        ArrayList<Hearing> hearings = new ArrayList<>();
+        Hearing hearing1 = Hearing.builder().sessionDate(SESSION_DATE).outcomeId("110").build();
+        Hearing hearing2 = Hearing.builder().sessionDate(SESSION_DATE).build();
+        hearings.add(hearing1);
+        hearings.add(hearing2);
+        AppealCase appealCase = AppealCase.builder().hearing(hearings).build();
+
+        List<Events> events = caseDataEventBuilder.buildAdjournedEvents(appealCase);
+
+        assertThat(events.size(), equalTo(1));
+
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -5,10 +5,12 @@ import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.hmcts.reform.sscs.models.GapsEvent;
@@ -28,7 +30,8 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
         AppealCase appealCaseWithMinorStatusId26 = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .majorStatus(super.buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED))
-            .minorStatus(super.getMinorStatusId26(TEST_DATE2))
+            .minorStatus(Collections.singletonList(
+                super.getMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
             .build();
 
         events = caseDataEventBuilder.buildPostponedEvent(
@@ -49,7 +52,8 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
         AppealCase appealWithPostponedAndMinorStatusWithSameDated = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .majorStatus(super.buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED, GapsEvent.HEARING_POSTPONED))
-            .minorStatus(super.getMinorStatusId26(TEST_DATE2))
+            .minorStatus(Collections.singletonList(
+                super.getMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
             .build();
 
         events = caseDataEventBuilder.buildPostponedEvent(appealWithPostponedAndMinorStatusWithSameDated);
@@ -62,7 +66,8 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
         AppealCase appealWithPostponedAndMinorStatusWithDifferentDates = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .majorStatus(super.buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED, GapsEvent.HEARING_POSTPONED))
-            .minorStatus(super.getMinorStatusId26(TEST_DATE))
+            .minorStatus(Collections.singletonList(
+                super.getMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE))))
             .build();
 
         events = caseDataEventBuilder.buildPostponedEvent(appealWithPostponedAndMinorStatusWithDifferentDates);
@@ -103,4 +108,32 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
         return new Object[]{new Object[]{null}, new Object[]{Collections.emptyList()}};
     }
 
+    @Test
+    public void givenTwoMinorStatusesArePresentThenTwoNewPostponedEventAreCreated() {
+        AppealCase appealWithTwoMinorStatusesAndNoPostponed = AppealCase.builder()
+            .appealCaseCaseCodeId("1")
+            .majorStatus(super.buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED))
+            .minorStatus(Arrays.asList(
+                getMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE)),
+                getMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
+            .build();
+
+        events = caseDataEventBuilder.buildPostponedEvent(appealWithTwoMinorStatusesAndNoPostponed);
+
+        System.out.println(events);
+        assertTrue("Two new postponed event should be created here", events.size() == 2);
+
+    }
+
+    @Test
+    @Ignore
+    public void givenTwoMinorStatusAndOneExistingPostponedEventArePresentThenOnlyOneNewPostponedEventIsCreated() {
+
+    }
+
+    @Test
+    @Ignore
+    public void givenTwoMinorStatusWithTheSameDateAnoNoPostponedPresentThenOnlyOneNewPostponedIsCreated() {
+
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -29,9 +29,10 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
     public void givenMinorStatusWithId26ThenAPostponedEventIsCreated() {
         AppealCase appealCaseWithMinorStatusId26 = AppealCase.builder()
             .appealCaseCaseCodeId("1")
-            .majorStatus(super.buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED))
+            .majorStatus(Collections.singletonList(
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)))
             .minorStatus(Collections.singletonList(
-                super.getMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
+                super.buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
             .build();
 
         events = caseDataEventBuilder.buildPostponedEvent(
@@ -51,9 +52,12 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
     public void givenAnExistingPostponedEventAndMinorStatusId26WithSameDatesThenNoNewPostponedEventIsCreated() {
         AppealCase appealWithPostponedAndMinorStatusWithSameDated = AppealCase.builder()
             .appealCaseCaseCodeId("1")
-            .majorStatus(super.buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED, GapsEvent.HEARING_POSTPONED))
+            .majorStatus(Arrays.asList(
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE),
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.HEARING_POSTPONED.getStatus(), TEST_DATE2)
+            ))
             .minorStatus(Collections.singletonList(
-                super.getMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
+                super.buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
             .build();
 
         events = caseDataEventBuilder.buildPostponedEvent(appealWithPostponedAndMinorStatusWithSameDated);
@@ -65,9 +69,12 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
     public void givenAnExistingPostponedEventAndMinorStatusId26WithDifferentDatesThenANewPostponedEventIsCreated() {
         AppealCase appealWithPostponedAndMinorStatusWithDifferentDates = AppealCase.builder()
             .appealCaseCaseCodeId("1")
-            .majorStatus(super.buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED, GapsEvent.HEARING_POSTPONED))
+            .majorStatus(Arrays.asList(
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE),
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.HEARING_POSTPONED.getStatus(), TEST_DATE2)
+            ))
             .minorStatus(Collections.singletonList(
-                super.getMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE))))
+                super.buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE))))
             .build();
 
         events = caseDataEventBuilder.buildPostponedEvent(appealWithPostponedAndMinorStatusWithDifferentDates);
@@ -93,7 +100,10 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
     public void whenMinorStatusIsNullOrEmptyThenPostponedEventIsNotCreated(List<MinorStatus> minorStatus) {
         AppealCase appealWithMinorStatusNull = AppealCase.builder()
             .appealCaseCaseCodeId("1")
-            .majorStatus(super.buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED, GapsEvent.HEARING_POSTPONED))
+            .majorStatus(Arrays.asList(
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE),
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.HEARING_POSTPONED.getStatus(), TEST_DATE2)
+            ))
             .minorStatus(minorStatus)
             .build();
 
@@ -112,10 +122,12 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
     public void givenTwoMinorStatusesArePresentThenTwoNewPostponedEventAreCreated() {
         AppealCase appealWithTwoMinorStatusesAndNoPostponed = AppealCase.builder()
             .appealCaseCaseCodeId("1")
-            .majorStatus(super.buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED))
+            .majorStatus(Collections.singletonList(
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
+            ))
             .minorStatus(Arrays.asList(
-                getMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE)),
-                getMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
+                buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE)),
+                buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
             .build();
 
         events = caseDataEventBuilder.buildPostponedEvent(appealWithTwoMinorStatusesAndNoPostponed);
@@ -130,10 +142,13 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
     public void givenTwoMinorStatusAndOneExistingPostponedEventArePresentThenOnlyOneNewPostponedEventIsCreated() {
         AppealCase appealWithTwoMinorStatusesAndNoPostponed = AppealCase.builder()
             .appealCaseCaseCodeId("1")
-            .majorStatus(super.buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED, GapsEvent.HEARING_POSTPONED))
+            .majorStatus(Arrays.asList(
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE),
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.HEARING_POSTPONED.getStatus(), TEST_DATE2)
+            ))
             .minorStatus(Arrays.asList(
-                getMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE)),
-                getMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
+                buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE)),
+                buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
             .build();
 
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -301,7 +301,8 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
      */
     @Test
     @Parameters({"6, ", "7, ", ", 6", ", 7"})
-    public void givenScenario3ThenPostponedIsCreated(String appealHearingId1, String appealHearingId2) throws Exception {
+    public void givenScenario3ThenPostponedIsCreated(String appealHearingId1, String appealHearingId2)
+        throws Exception {
         AppealCase appeal = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .majorStatus(Collections.singletonList(

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -31,7 +31,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
             .majorStatus(Collections.singletonList(
                 super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)))
             .minorStatus(Collections.singletonList(
-                super.buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
+                super.buildMinorStatusGivenIdAndDate("26", TEST_DATE2)))
             .build();
 
         events = caseDataEventBuilder.buildPostponedEvent(
@@ -56,7 +56,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
                 super.buildMajorStatusGivenStatusAndDate(GapsEvent.HEARING_POSTPONED.getStatus(), TEST_DATE2)
             ))
             .minorStatus(Collections.singletonList(
-                super.buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
+                super.buildMinorStatusGivenIdAndDate("26", TEST_DATE2)))
             .build();
 
         events = caseDataEventBuilder.buildPostponedEvent(appealWithPostponedAndMinorStatusWithSameDated);
@@ -73,7 +73,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
                 super.buildMajorStatusGivenStatusAndDate(GapsEvent.HEARING_POSTPONED.getStatus(), TEST_DATE2)
             ))
             .minorStatus(Collections.singletonList(
-                super.buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE))))
+                super.buildMinorStatusGivenIdAndDate("26", TEST_DATE)))
             .build();
 
         events = caseDataEventBuilder.buildPostponedEvent(appealWithPostponedAndMinorStatusWithDifferentDates);
@@ -125,8 +125,8 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
                 super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
             ))
             .minorStatus(Arrays.asList(
-                buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE)),
-                buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
+                buildMinorStatusGivenIdAndDate("26", TEST_DATE),
+                buildMinorStatusGivenIdAndDate("26", TEST_DATE2)))
             .build();
 
         events = caseDataEventBuilder.buildPostponedEvent(appealWithTwoMinorStatusesAndNoPostponed);
@@ -146,8 +146,8 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
                 super.buildMajorStatusGivenStatusAndDate(GapsEvent.HEARING_POSTPONED.getStatus(), TEST_DATE2)
             ))
             .minorStatus(Arrays.asList(
-                buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE)),
-                buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE2))))
+                buildMinorStatusGivenIdAndDate("26", TEST_DATE),
+                buildMinorStatusGivenIdAndDate("26", TEST_DATE2)))
             .build();
 
         events = caseDataEventBuilder.buildPostponedEvent(appealWithTwoMinorStatusesAndNoPostponed);
@@ -166,8 +166,8 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
                 super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
             ))
             .minorStatus(Arrays.asList(
-                buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE)),
-                buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE))))
+                buildMinorStatusGivenIdAndDate("26", TEST_DATE),
+                buildMinorStatusGivenIdAndDate("26", TEST_DATE)))
             .build();
 
         events = caseDataEventBuilder.buildPostponedEvent(appealWithTwoMinorStatusesAndNoPostponed);

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -27,6 +27,7 @@ import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
 public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
 
     private static final String SESSION_DATE = "2017-05-23T00:00:00+01:00";
+    private static final String LOCAL_SESSION_DATE = "2017-05-23T00:00:00";
     private final CaseDataEventBuilder caseDataEventBuilder = new CaseDataEventBuilder();
     private List<Events> events;
 
@@ -194,7 +195,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
 
         assertThat(event.getType(), equalTo(GapsEvent.HEARING_ADJOURNED.getType()));
         assertThat(event.getDescription(), equalTo(GapsEvent.HEARING_ADJOURNED.getDescription()));
-        assertThat(event.getDate(), equalTo(SESSION_DATE));
+        assertThat(event.getDate(), equalTo(LOCAL_SESSION_DATE));
 
     }
 
@@ -212,7 +213,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
 
         assertThat(event.getType(), equalTo(GapsEvent.HEARING_ADJOURNED.getType()));
         assertThat(event.getDescription(), equalTo(GapsEvent.HEARING_ADJOURNED.getDescription()));
-        assertThat(event.getDate(), equalTo(SESSION_DATE));
+        assertThat(event.getDate(), equalTo(LOCAL_SESSION_DATE));
 
     }
 
@@ -232,7 +233,7 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
 
         assertThat(event.getType(), equalTo(GapsEvent.HEARING_ADJOURNED.getType()));
         assertThat(event.getDescription(), equalTo(GapsEvent.HEARING_ADJOURNED.getDescription()));
-        assertThat(event.getDate(), equalTo(SESSION_DATE));
+        assertThat(event.getDate(), equalTo(LOCAL_SESSION_DATE));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Event;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
 
+
 @RunWith(JUnitParamsRunner.class)
 public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
 
@@ -115,7 +116,6 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
         events = caseDataEventBuilder.buildPostponedEvent(appealWithMinorStatusNull);
 
         assertTrue("No Postponed event should be created here", events.isEmpty());
-
     }
 
     @SuppressWarnings("PMD.UnusedPrivateMethod")
@@ -196,7 +196,6 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
         assertThat(event.getType(), equalTo(GapsEvent.HEARING_ADJOURNED.getType()));
         assertThat(event.getDescription(), equalTo(GapsEvent.HEARING_ADJOURNED.getDescription()));
         assertThat(event.getDate(), equalTo(LOCAL_SESSION_DATE));
-
     }
 
     @Test
@@ -214,7 +213,6 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
         assertThat(event.getType(), equalTo(GapsEvent.HEARING_ADJOURNED.getType()));
         assertThat(event.getDescription(), equalTo(GapsEvent.HEARING_ADJOURNED.getDescription()));
         assertThat(event.getDate(), equalTo(LOCAL_SESSION_DATE));
-
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -5,14 +5,19 @@ import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.List;
-import org.junit.Ignore;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import uk.gov.hmcts.reform.sscs.models.GapsEvent;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.MinorStatus;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Event;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
 
+@RunWith(JUnitParamsRunner.class)
 public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
 
     private final CaseDataEventBuilder caseDataEventBuilder = new CaseDataEventBuilder();
@@ -79,14 +84,23 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
     }
 
     @Test
-    @Ignore
-    public void whenMinorStatusIsNullThenPostponedEventIsNotCreated() {
+    @Parameters(method = "getMinotStatusListParameters")
+    public void whenMinorStatusIsNullOrEmptyThenPostponedEventIsNotCreated(List<MinorStatus> minorStatus) {
+        AppealCase appealWithMinorStatusNull = AppealCase.builder()
+            .appealCaseCaseCodeId("1")
+            .majorStatus(super.buildMajorStatusGivenStatuses(GapsEvent.APPEAL_RECEIVED, GapsEvent.HEARING_POSTPONED))
+            .minorStatus(minorStatus)
+            .build();
+
+        events = caseDataEventBuilder.buildPostponedEvent(appealWithMinorStatusNull);
+
+        assertTrue("No Postponed event should be created here", events.isEmpty());
 
     }
 
-    @Test
-    @Ignore
-    public void whenMinorStatusIsEmptyThenPostponedEventIsNotCreated() {
-
+    @SuppressWarnings("PMD.UnusedPrivateMethod")
+    private Object getMinotStatusListParameters() {
+        return new Object[]{new Object[]{null}, new Object[]{Collections.emptyList()}};
     }
+
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -399,10 +399,10 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBase {
         AppealCase appeal = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .majorStatus(Arrays.asList(
-                super.buildMajorStatusGivenStatusAndDate(GapsEvent.RESPONSE_RECEIVED.getStatus(),
-                    RESPONSE_RECEIVED_DATE),
                 super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(),
-                    APPEAL_RECEIVED_DATE)
+                    APPEAL_RECEIVED_DATE),
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.RESPONSE_RECEIVED.getStatus(),
+                    RESPONSE_RECEIVED_DATE)
             ))
             .postponementRequests(Collections.singletonList(
                 new PostponementRequests(

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -247,4 +247,13 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
 
         assertThat(events.size(), equalTo(0));
     }
+
+    @Test
+    public void shouldReturnEmptyListIfThereAreNoHearing() {
+        AppealCase appealCase = AppealCase.builder().build();
+
+        List<Events> events = caseDataEventBuilder.buildAdjournedEvents(appealCase);
+
+        assertThat(events, equalTo(Collections.EMPTY_LIST));
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataEventBuilderTest.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.List;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.hmcts.reform.sscs.models.GapsEvent;
@@ -157,13 +156,22 @@ public class CaseDataEventBuilderTest extends CaseDataBuilderBaseTest {
         LocalDateTime actualEvenDate = LocalDateTime.parse(events.get(0).getValue().getDate());
         LocalDateTime expectedEventDate = ZonedDateTime.parse(TEST_DATE).toLocalDateTime();
         assertTrue("", actualEvenDate.equals(expectedEventDate));
-
-
     }
 
     @Test
-    @Ignore
     public void givenTwoMinorStatusWithTheSameDateAnoNoPostponedPresentThenOnlyOneNewPostponedIsCreated() {
+        AppealCase appealWithTwoMinorStatusesAndNoPostponed = AppealCase.builder()
+            .appealCaseCaseCodeId("1")
+            .majorStatus(Collections.singletonList(
+                super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), TEST_DATE)
+            ))
+            .minorStatus(Arrays.asList(
+                buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE)),
+                buildMinorStatusGivenIdAndDate("26", ZonedDateTime.parse(TEST_DATE))))
+            .build();
 
+        events = caseDataEventBuilder.buildPostponedEvent(appealWithTwoMinorStatusesAndNoPostponed);
+
+        assertTrue("Only one postponed should be created here", events.size() == 1);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/PostponedEventInferredFromCcdTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/PostponedEventInferredFromCcdTest.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.reform.sscs.services.mapper;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.List;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.PostponementRequests;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Hearing;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.HearingDetails;
+
+@RunWith(JUnitParamsRunner.class)
+public class PostponedEventInferredFromCcdTest {
+
+    @Test
+    @Parameters({"1, 1, true", "1, 2, false"})
+    public void givenPostponedRequestAndHearingThenReturnTrueIfThereIsAMatch(String appealHearingId,
+                                                                             String hearingId, boolean expected) {
+        PostponedEventInferredFromCcd postponedEventInferredFromCcd = new PostponedEventInferredFromCcd();
+
+        List<PostponementRequests> postponementRequests = Collections.singletonList(
+            new PostponementRequests("Y", appealHearingId, null,
+                null)
+        );
+
+        List<Hearing> hearingList = Collections.singletonList(Hearing.builder()
+            .value(HearingDetails.builder()
+                .hearingId(hearingId)
+                .build())
+            .build());
+
+        boolean actual = postponedEventInferredFromCcd.matchToHearingId(postponementRequests, hearingList);
+
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/PostponedEventInferredFromDeltaTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/PostponedEventInferredFromDeltaTest.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.reform.sscs.services.mapper;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing;
+import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.PostponementRequests;
+
+public class PostponedEventInferredFromDeltaTest {
+    @Test
+    public void givenPostponedRequestMatchesToHearingThenReturnTrue() {
+        PostponedEventInferredFromDelta postponedEventInferredFromDelta = new PostponedEventInferredFromDelta();
+
+        List<PostponementRequests> postponementRequests = Collections.singletonList(
+            new PostponementRequests("Y", "1", null,
+                null)
+        );
+        List<Hearing> hearingList = Collections.singletonList(Hearing.builder().hearingId("1").build());
+
+        boolean actual = postponedEventInferredFromDelta.matchToHearingId(postponementRequests, hearingList);
+        assertTrue(actual);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/PostponedEventInferredFromDeltaTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/PostponedEventInferredFromDeltaTest.java
@@ -1,25 +1,33 @@
 package uk.gov.hmcts.reform.sscs.services.mapper;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
 import java.util.List;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.PostponementRequests;
 
+@RunWith(JUnitParamsRunner.class)
 public class PostponedEventInferredFromDeltaTest {
+
     @Test
-    public void givenPostponedRequestMatchesToHearingThenReturnTrue() {
+    @Parameters({"1, 1, true", "1, 2, false"})
+    public void givenPostponedRequestMatchesToHearingThenReturnTrue(String appealHearingId, String hearingId,
+                                                                    boolean expected) {
         PostponedEventInferredFromDelta postponedEventInferredFromDelta = new PostponedEventInferredFromDelta();
 
         List<PostponementRequests> postponementRequests = Collections.singletonList(
-            new PostponementRequests("Y", "1", null,
+            new PostponementRequests("Y", appealHearingId, null,
                 null)
         );
-        List<Hearing> hearingList = Collections.singletonList(Hearing.builder().hearingId("1").build());
+        List<Hearing> hearingList = Collections.singletonList(Hearing.builder().hearingId(hearingId).build());
 
         boolean actual = postponedEventInferredFromDelta.matchToHearingId(postponementRequests, hearingList);
-        assertTrue(actual);
+
+        assertEquals(expected, actual);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/PostponedEventInferredFromDeltaTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/PostponedEventInferredFromDeltaTest.java
@@ -16,8 +16,8 @@ public class PostponedEventInferredFromDeltaTest {
 
     @Test
     @Parameters({"1, 1, true", "1, 2, false"})
-    public void givenPostponedRequestMatchesToHearingThenReturnTrue(String appealHearingId, String hearingId,
-                                                                    boolean expected) {
+    public void givenPostponedRequestAndHearingThenReturnTrueIfThereIsAMatch(String appealHearingId, String hearingId,
+                                                                             boolean expected) {
         PostponedEventInferredFromDelta postponedEventInferredFromDelta = new PostponedEventInferredFromDelta();
 
         List<PostponementRequests> postponementRequests = Collections.singletonList(

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/TransformAppealCaseToCaseDataTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/TransformAppealCaseToCaseDataTest.java
@@ -17,7 +17,8 @@ public class TransformAppealCaseToCaseDataTest {
     @Test
     public void givenACaseData_shouldBeTransformToCaseDataWithSubscriptionsAndAppealNumber() throws Exception {
         ReferenceDataService referenceDataService = mock(ReferenceDataService.class);
-        CaseDataBuilder caseDataBuilder = new CaseDataBuilder(referenceDataService);
+        CaseDataEventBuilder caseDataEventBuilder = mock(CaseDataEventBuilder.class);
+        CaseDataBuilder caseDataBuilder = new CaseDataBuilder(referenceDataService, caseDataEventBuilder);
         TransformAppealCaseToCaseData transformAppealCaseToCaseData =
             new TransformAppealCaseToCaseData(caseDataBuilder);
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/refdata/ReferenceDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/refdata/ReferenceDataServiceTest.java
@@ -7,7 +7,6 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.sscs.refdata.domain.RefKeyField.BENEFIT_DESC;
 
 import java.util.Map;
 import org.junit.Before;
@@ -48,7 +47,7 @@ public class ReferenceDataServiceTest {
     public void givenBenefitTypeIsNotFound_ReturnErr() {
         when(refDataRepo.find(RefKey.CASE_CODE, "1", RefKeyField.BEN_ASSESS_TYPE_ID)).thenReturn("123");
         when(refDataRepo.find(RefKey.BEN_ASSESS_TYPE, "123", RefKeyField.BAT_CODE)).thenReturn("007");
-        when(refDataRepo.find(eq(RefKey.BAT_CODE_MAP), anyString(), eq(BENEFIT_DESC)))
+        when(refDataRepo.find(eq(RefKey.BAT_CODE_MAP), anyString(), eq(RefKeyField.BENEFIT_DESC)))
             .thenThrow(new RuntimeException());
         referenceDataService.setRefDataRepo(refDataRepo);
         assertTrue("ERR".equals(referenceDataService.getBenefitType("1")));

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/xml/XmlValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/xml/XmlValidatorTest.java
@@ -18,7 +18,7 @@ import uk.gov.hmcts.reform.sscs.services.sftp.SftpSshService;
 public class XmlValidatorTest {
 
     @Mock
-    SftpSshService sftpSshService;
+    private SftpSshService sftpSshService;
 
     private XmlValidator validator;
 
@@ -65,8 +65,7 @@ public class XmlValidatorTest {
         try {
             validator.validateXml(invalidDelta);
             fail();
-        } catch (GapsValidationException e) {
-            //
+        } catch (GapsValidationException e) { //NOPMD
         }
 
         verify(sftpSshService).readExtractFile(invalidDelta);

--- a/src/test/resources/CaseDetailsWithHearings.json
+++ b/src/test/resources/CaseDetailsWithHearings.json
@@ -8,41 +8,67 @@
   "locked_by_user_id": null,
   "security_level": null,
   "case_data": {
-    "dwpTimeExtension": [{
-      "value": {
-        "requested": "Yes",
-        "granted": "Yes"
-      },
-      "id": "47d4b988-2532-4313-b853-5ccc0a62b744"
-    }, {
-      "value": {
-        "requested": "Yes",
-        "granted": "No"
-      },
-      "id": "ba6d93ac-4e3e-42d5-b4a4-552f9abfa952"
-    }],
-    "generatedNino": "CA 36 98 74 A",
-    "hearings": [{
-      "value": {
-        "venue": {
-          "name": "Prudential House",
-          "address": {
-            "line1": "36 Dale Street",
-            "line2": "",
-            "town": "Liverpool",
-            "county": "Merseyside",
-            "postcode": "L2 5UZ"
-          },
-          "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+    "dwpTimeExtension": [
+      {
+        "value": {
+          "requested": "Yes",
+          "granted": "Yes"
         },
-        "hearingDate": "2017-05-24",
-        "time": "10:00",
-        "adjourned": "Yes"
+        "id": "47d4b988-2532-4313-b853-5ccc0a62b744"
       },
-      "id": "e1ba468b-9a24-494b-8b7a-26cb3b75c890"
-    }],
+      {
+        "value": {
+          "requested": "Yes",
+          "granted": "No"
+        },
+        "id": "ba6d93ac-4e3e-42d5-b4a4-552f9abfa952"
+      }
+    ],
+    "generatedNino": "CA 36 98 74 A",
+    "hearings": [
+      {
+        "value": {
+          "venue": {
+            "name": "Prudential House",
+            "address": {
+              "line1": "36 Dale Street",
+              "line2": "",
+              "town": "Liverpool",
+              "county": "Merseyside",
+              "postcode": "L2 5UZ"
+            },
+            "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+          },
+          "hearingDate": "2017-05-24",
+          "time": "10:00",
+          "adjourned": "Yes",
+          "hearingId": "6"
+        },
+        "id": "e1ba468b-9a24-494b-8b7a-26cb3b75c890"
+      },
+      {
+        "value": {
+          "venue": {
+            "name": "Prudential House",
+            "address": {
+              "line1": "36 Dale Street",
+              "line2": "",
+              "town": "Liverpool",
+              "county": "Merseyside",
+              "postcode": "L2 5UZ"
+            },
+            "googleMapLink": "https://www.google.com/maps/place/36+Dale+Street+Liverpool+Merseyside+L2+5UZ/@53.407820,-2.988509"
+          },
+          "hearingDate": "2017-05-24",
+          "time": "10:00",
+          "adjourned": "Yes",
+          "hearingId": "7"
+        },
+        "id": "e1ba468b-9a24-494b-8b7a-26cb3b75c890"
+      }
+    ],
     "evidence": {
-      "documents": [ ]
+      "documents": []
     },
     "caseReference": "SC068/17/00011",
     "generatedSurname": "Cherry",
@@ -71,14 +97,16 @@
       }
     },
     "generatedEmail": null,
-    "events": [{
-      "value": {
-        "date": "2017-05-23T13:18:15.073",
-        "type": "appealReceived",
-        "description": "Appeal received"
-      },
-      "id": "3cae07f7-d6e8-4695-8268-65ebb44cb497"
-    }],
+    "events": [
+      {
+        "value": {
+          "date": "2017-05-23T13:18:15.073",
+          "type": "appealReceived",
+          "description": "Appeal received"
+        },
+        "id": "3cae07f7-d6e8-4695-8268-65ebb44cb497"
+      }
+    ],
     "generatedMobile": null
   },
   "security_classification": "PUBLIC"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCS-3140

### Change description ###

Given that there is a gaps2 extract with an appeal with postponed and no hearing elements
When the appeals current major status is 18 and postponement_granted = Y
and there exists a hearing in past with hearing_id = postponement_hearing_id
Then create a POSTPONED event with major status date_set as postponed event data.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
