### PR TITLE
SSCS-3428 Update the RPC and Region based on hearing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -230,6 +230,8 @@ dependencies {
   compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310'
   compile group: 'io.rest-assured', name: 'rest-assured', version: '3.0.7'
 
+  compile group: 'org.apache.poi', name: 'poi-ooxml', version: '3.17'
+
   compileOnly 'org.projectlombok:lombok:1.16.20'
   apt "org.projectlombok:lombok:1.16.20"
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/models/deserialize/gaps2/Parties.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/models/deserialize/gaps2/Parties.java
@@ -1,9 +1,11 @@
 package uk.gov.hmcts.reform.sscs.models.deserialize.gaps2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
 import lombok.Value;
 
 @Value
+@Builder
 public class Parties {
     private String initials;
     private String title;

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/ccd/CcdCasesSender.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/ccd/CcdCasesSender.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.sscs.models.idam.IdamTokens;
-import uk.gov.hmcts.reform.sscs.models.refdata.RegionalProcessingCenter;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.*;
 import uk.gov.hmcts.reform.sscs.services.refdata.RegionalProcessingCenterService;
 import uk.gov.hmcts.reform.sscs.util.CcdUtil;
@@ -22,7 +21,6 @@ public class CcdCasesSender {
     public static final String REGION = "region";
     private final CreateCcdService createCcdService;
     private final UpdateCcdService updateCcdService;
-    private final RegionalProcessingCenterService regionalProcessingCenterService;
 
     @Autowired
     CcdCasesSender(CreateCcdService createCcdService,
@@ -30,11 +28,9 @@ public class CcdCasesSender {
                    RegionalProcessingCenterService regionalProcessingCenterService) {
         this.createCcdService = createCcdService;
         this.updateCcdService = updateCcdService;
-        this.regionalProcessingCenterService = regionalProcessingCenterService;
     }
 
     public void sendCreateCcdCases(CaseData caseData, IdamTokens idamTokens) {
-        addRegionalProcessingCenter(caseData);
         createCcdService.create(caseData, idamTokens);
     }
 
@@ -66,17 +62,10 @@ public class CcdCasesSender {
     private void ifThereIsEventChangesThenUpdateCase(CaseData caseData, CaseDetails existingCcdCase,
                                                      IdamTokens idamTokens) {
         if (thereIsAnEventChange(caseData, existingCcdCase)) {
-            addRegionalProcessingCenterIfItsNotPresent(caseData, existingCcdCase);
             addMissingExistingHearings(caseData, existingCcdCase);
             updateCcdService.update(caseData, existingCcdCase.getId(), caseData.getLatestEventType(), idamTokens);
         } else {
             log.debug("*** case-loader *** No case update needed for case reference: {}", caseData.getCaseReference());
-        }
-    }
-
-    private void addRegionalProcessingCenterIfItsNotPresent(CaseData caseData, CaseDetails existingCcdCase) {
-        if (null == existingCcdCase.getData().get(REGION)) {
-            addRegionalProcessingCenter(caseData);
         }
     }
 
@@ -122,15 +111,6 @@ public class CcdCasesSender {
         Evidence existingEvidence = buildExistingEvidence(existingCase);
         if (newEvidence != null && existingEvidence != null && !existingEvidence.equals(newEvidence)) {
             updateCcdService.update(caseData, existingCase.getId(), "evidenceReceived", idamTokens);
-        }
-    }
-
-    private void addRegionalProcessingCenter(CaseData caseData) {
-        RegionalProcessingCenter regionalProcessingCenter = regionalProcessingCenterService
-            .getByScReferenceCode(caseData.getCaseReference());
-        if (null != regionalProcessingCenter) {
-            caseData.setRegion(regionalProcessingCenter.getName());
-            caseData.setRegionalProcessingCenter(regionalProcessingCenter);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/TransformAppealCaseToCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/TransformAppealCaseToCaseData.java
@@ -45,6 +45,8 @@ public class TransformAppealCaseToCaseData {
         String generatedEmail = "";
         String generatedMobile = "";
         Appellant appellant = null;
+        RegionalProcessingCenter regionalProcessingCenter = null;
+        String region = null;
 
         if (party.isPresent()) {
             name = caseDataBuilder.buildName(party.get());
@@ -61,6 +63,9 @@ public class TransformAppealCaseToCaseData {
                 .contact(contact)
                 .identity(identity)
                 .build();
+
+            regionalProcessingCenter = caseDataBuilder.buildRegionalProcessingCentre(appealCase, party.get());
+            region = (regionalProcessingCenter != null) ? regionalProcessingCenter.getName() : null;
         }
 
         BenefitType benefitType = caseDataBuilder.buildBenefitType(appealCase);
@@ -72,8 +77,6 @@ public class TransformAppealCaseToCaseData {
             .build();
 
         List<Hearing> hearingsList = caseDataBuilder.buildHearings(appealCase);
-        RegionalProcessingCenter regionalProcessingCenter = caseDataBuilder.buildRegionalProcessingCentre(appealCase);
-        String region = (regionalProcessingCenter != null) ? regionalProcessingCenter.getName() : null;
 
         Evidence evidence = caseDataBuilder.buildEvidence(appealCase);
 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/TransformAppealCaseToCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/TransformAppealCaseToCaseData.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Parties;
+import uk.gov.hmcts.reform.sscs.models.refdata.RegionalProcessingCenter;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Appeal;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Appellant;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.BenefitType;
@@ -71,6 +72,8 @@ public class TransformAppealCaseToCaseData {
             .build();
 
         List<Hearing> hearingsList = caseDataBuilder.buildHearings(appealCase);
+        RegionalProcessingCenter regionalProcessingCenter = caseDataBuilder.buildRegionalProcessingCentre(appealCase);
+        String region = (regionalProcessingCenter != null) ? regionalProcessingCenter.getName() : null;
 
         Evidence evidence = caseDataBuilder.buildEvidence(appealCase);
 
@@ -81,6 +84,8 @@ public class TransformAppealCaseToCaseData {
             .caseReference(appealCase.getAppealCaseRefNum())
             .appeal(appeal)
             .hearings(hearingsList)
+            .regionalProcessingCenter(regionalProcessingCenter)
+            .region(region)
             .evidence(evidence)
             .dwpTimeExtension(dwpTimeExtensionList)
             .events(events)

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/TransformAppealCaseToCaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/mapper/TransformAppealCaseToCaseData.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.sscs.services.mapper;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Parties;
@@ -22,6 +23,9 @@ import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Name;
 
 @Service
 public class TransformAppealCaseToCaseData {
+
+    @Value("${rpc.venue.id.enabled}")
+    private boolean lookupRpcByVenueId;
 
     private final CaseDataBuilder caseDataBuilder;
 
@@ -64,8 +68,10 @@ public class TransformAppealCaseToCaseData {
                 .identity(identity)
                 .build();
 
-            regionalProcessingCenter = caseDataBuilder.buildRegionalProcessingCentre(appealCase, party.get());
-            region = (regionalProcessingCenter != null) ? regionalProcessingCenter.getName() : null;
+            if (lookupRpcByVenueId) {
+                regionalProcessingCenter = caseDataBuilder.buildRegionalProcessingCentre(appealCase, party.get());
+                region = (regionalProcessingCenter != null) ? regionalProcessingCenter.getName() : null;
+            }
         }
 
         BenefitType benefitType = caseDataBuilder.buildBenefitType(appealCase);

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/refdata/AirLookupService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/refdata/AirLookupService.java
@@ -1,0 +1,99 @@
+package uk.gov.hmcts.reform.sscs.services.refdata;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
+import org.apache.poi.poifs.filesystem.NPOIFSFileSystem;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.slf4j.Logger;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+
+
+/**
+ * Service that ingests a spreadsheet and a csv file containing the
+ * venues and regional centres for handling all post codes.
+ */
+
+@Service
+public class AirLookupService {
+    private static final Logger LOG = getLogger(AirLookupService.class);
+    private static final int POSTCODE_COLUMN = 1;
+    private static final int REGIONAL_CENTRE_COLUMN = 3;
+
+    private Map<String, String> lookupRegionalCentreByPostCode;
+
+    /**
+     * Read in the AIRLookup RC spreadsheet and the venue id csv file.
+     */
+    @PostConstruct
+    public void init() {
+        lookupRegionalCentreByPostCode = new HashMap<>();
+
+        try {
+            ClassPathResource classPathResource = new ClassPathResource("reference-data/AIRLookup RC.xls");
+
+            parseSpreadSheet(classPathResource);
+
+            LOG.debug("Regional centre data has " + lookupRegionalCentreByPostCode.keySet().size() + " post codes");
+
+
+            LOG.debug("Successfully loaded lookup data for postcode endpoint");
+        } catch (IOException e) {
+            LOG.error("Unable to read in spreadsheet with post code data: reference-data/AIRLookup RC.xls", e);
+        }
+    }
+
+    /**
+     * Read in spreadsheet and populate the Map with postcode.
+     * @param classPathResource The file containing the spreadsheet
+     * @throws IOException pass up any IO errors
+     */
+    private void parseSpreadSheet(ClassPathResource classPathResource) throws IOException {
+        try (NPOIFSFileSystem fs = new NPOIFSFileSystem(classPathResource.getInputStream());
+             HSSFWorkbook wb = new HSSFWorkbook(fs.getRoot(), true)) {
+
+            for (Sheet sheet: wb) {
+                if (sheet.getSheetName().equals("AIR")) {
+                    for (Row row : sheet) {
+                        Cell postcodeCell = row.getCell(POSTCODE_COLUMN);
+                        Cell adminGroupCell = row.getCell(REGIONAL_CENTRE_COLUMN);
+                        if (postcodeCell != null && adminGroupCell != null
+                            && postcodeCell.getCellTypeEnum() == CellType.STRING
+                            && adminGroupCell.getCellTypeEnum() == CellType.STRING) {
+                            LOG.debug("Post code: "
+                                + postcodeCell.getRichStringCellValue().getString().toLowerCase(Locale.getDefault())
+                                + " Regional office: "
+                                + adminGroupCell.getRichStringCellValue().getString());
+                            lookupRegionalCentreByPostCode.put(
+                                postcodeCell.getRichStringCellValue().getString().toLowerCase(Locale.getDefault()),
+                                adminGroupCell.getRichStringCellValue().getString()
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public String lookupRegionalCentre(String postcode) {
+        //full post code
+        if (postcode.length() >= 5) {
+            int index = postcode.length() - 3;
+            //trim last 3 chars to leave the outcode
+            String outcode = postcode.toLowerCase(Locale.getDefault()).substring(0, index).trim();
+            return lookupRegionalCentreByPostCode.get(outcode);
+        } else {
+            //try it as the outcode
+            return lookupRegionalCentreByPostCode.get(postcode.toLowerCase(Locale.getDefault()).trim());
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/refdata/RegionalProcessingCenterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/refdata/RegionalProcessingCenterService.java
@@ -27,8 +27,11 @@ public class RegionalProcessingCenterService {
 
     private static final String RPC_DATA_JSON = "reference-data/rpc-data.json";
     private static final String CSV_FILE_PATH = "reference-data/sscs-venues.csv";
+    private static final char SEPARATOR_CHAR = '/';
+    private static final String SSCS_BIRMINGHAM = "SSCS Birmingham";
 
     private Map<String, RegionalProcessingCenter>  regionalProcessingCenterMap  = newHashMap();
+    private final Map<String, String> sccodeRegionalProcessingCentermap = newHashMap();
     private final Map<String, String> venueIdToRegionalProcessingCentre = new HashMap<>();
 
     private final AirLookupService airLookupService;
@@ -52,6 +55,7 @@ public class RegionalProcessingCenterService {
             List<String[]> linesList = reader.readAll();
 
             linesList.forEach(line -> {
+                sccodeRegionalProcessingCentermap.put(line[1], line[2]);
                 venueIdToRegionalProcessingCentre.put(line[0], line[2]);
             });
         } catch (IOException e) {
@@ -72,7 +76,6 @@ public class RegionalProcessingCenterService {
                 new RegionalProcessingCenterServiceException(e));
         }
     }
-
 
     public RegionalProcessingCenter getByScReferenceCode(String referenceNumber) {
 
@@ -102,5 +105,9 @@ public class RegionalProcessingCenterService {
 
     public Map<String, RegionalProcessingCenter> getRegionalProcessingCenterMap() {
         return regionalProcessingCenterMap;
+    }
+
+    public Map<String, String> getSccodeRegionalProcessingCentermap() {
+        return sccodeRegionalProcessingCentermap;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/refdata/RegionalProcessingCenterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/refdata/RegionalProcessingCenterService.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import javax.annotation.PostConstruct;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.exceptions.RegionalProcessingCenterServiceException;
@@ -29,6 +30,14 @@ public class RegionalProcessingCenterService {
 
     private Map<String, RegionalProcessingCenter>  regionalProcessingCenterMap  = newHashMap();
     private final Map<String, String> venueIdToRegionalProcessingCentre = new HashMap<>();
+
+    private final AirLookupService airLookupService;
+
+    @Autowired
+    public RegionalProcessingCenterService(AirLookupService airLookupService) {
+        this.airLookupService = airLookupService;
+    }
+
 
     @PostConstruct
     public void init() {
@@ -84,6 +93,11 @@ public class RegionalProcessingCenterService {
     public RegionalProcessingCenter getByVenueId(String venueId) {
         String rpc = venueIdToRegionalProcessingCentre.get(venueId);
         return regionalProcessingCenterMap.get(rpc);
+    }
+
+    public RegionalProcessingCenter getByPostcode(String postcode) {
+        String regionalProcessingCentreName = airLookupService.lookupRegionalCentre(postcode);
+        return regionalProcessingCenterMap.get("SSCS " + regionalProcessingCentreName);
     }
 
     public Map<String, RegionalProcessingCenter> getRegionalProcessingCenterMap() {

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/refdata/RegionalProcessingCenterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/refdata/RegionalProcessingCenterService.java
@@ -9,6 +9,7 @@ import com.opencsv.CSVReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.PostConstruct;
@@ -19,20 +20,15 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.sscs.exceptions.RegionalProcessingCenterServiceException;
 import uk.gov.hmcts.reform.sscs.models.refdata.RegionalProcessingCenter;
 
-
-
 @Service
 public class RegionalProcessingCenterService {
     private static final Logger LOG = getLogger(RegionalProcessingCenterService.class);
 
     private static final String RPC_DATA_JSON = "reference-data/rpc-data.json";
     private static final String CSV_FILE_PATH = "reference-data/sscs-venues.csv";
-    private static final char SEPARATOR_CHAR = '/';
-    private static final String SSCS_BIRMINGHAM = "SSCS Birmingham";
 
     private Map<String, RegionalProcessingCenter>  regionalProcessingCenterMap  = newHashMap();
-    private final Map<String, String> sccodeRegionalProcessingCentermap = newHashMap();
-
+    private final Map<String, String> venueIdToRegionalProcessingCentre = new HashMap<>();
 
     @PostConstruct
     public void init() {
@@ -46,9 +42,9 @@ public class RegionalProcessingCenterService {
 
             List<String[]> linesList = reader.readAll();
 
-            linesList.forEach(line ->
-                    sccodeRegionalProcessingCentermap.put(line[1], line[2])
-            );
+            linesList.forEach(line -> {
+                venueIdToRegionalProcessingCentre.put(line[0], line[2]);
+            });
         } catch (IOException e) {
             LOG.error("Error occurred while loading the sscs venues reference data file: " + CSV_FILE_PATH,
                 new RegionalProcessingCenterServiceException(e));
@@ -85,12 +81,12 @@ public class RegionalProcessingCenterService {
         }
     }
 
+    public RegionalProcessingCenter getByVenueId(String venueId) {
+        String rpc = venueIdToRegionalProcessingCentre.get(venueId);
+        return regionalProcessingCenterMap.get(rpc);
+    }
+
     public Map<String, RegionalProcessingCenter> getRegionalProcessingCenterMap() {
         return regionalProcessingCenterMap;
     }
-
-    public Map<String, String> getSccodeRegionalProcessingCentermap() {
-        return sccodeRegionalProcessingCentermap;
-    }
-
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -77,9 +77,9 @@ slot.name: ${SLOT:dev}
 
 test.url: ${TEST_URL:http://localhost:8082}
 
+rpc.venue.id.enabled: ${RPC_VENUE_ID_ENABLED:false}
 ---
 spring:
     profiles: development
 
 scheduling.enabled: false
-

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/ccd/CcdCasesSenderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/ccd/CcdCasesSenderTest.java
@@ -1,10 +1,13 @@
 package uk.gov.hmcts.reform.sscs.services.ccd;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.*;
-import static org.mockito.Matchers.*;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.sscs.CaseDetailsUtils.getCaseDetails;
 import static uk.gov.hmcts.reform.sscs.models.GapsEvent.APPEAL_RECEIVED;
 import static uk.gov.hmcts.reform.sscs.models.GapsEvent.RESPONSE_RECEIVED;
@@ -20,11 +23,25 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.sscs.models.GapsEvent;
 import uk.gov.hmcts.reform.sscs.models.idam.IdamTokens;
 import uk.gov.hmcts.reform.sscs.models.refdata.RegionalProcessingCenter;
-import uk.gov.hmcts.reform.sscs.models.serialize.ccd.*;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Appeal;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Appellant;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.BenefitType;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.CaseData;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Contact;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Doc;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Documents;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Event;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Events;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Evidence;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Hearing;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.HearingDetails;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Identity;
+import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Name;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.subscriptions.Subscription;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.subscriptions.Subscriptions;
 import uk.gov.hmcts.reform.sscs.services.refdata.RegionalProcessingCenterService;
@@ -107,10 +124,26 @@ public class CcdCasesSenderTest {
 
     @Test
     public void shouldCreateInCcdGivenThereIsANewCaseAfterIgnoreCasesBeforeDateProperty() {
+        when(regionalProcessingCenterService.getByScReferenceCode(anyString()))
+            .thenReturn(getRegionalProcessingCenter());
+        ccdCasesSender.sendCreateCcdCases(buildCaseData(APPEAL_RECEIVED), idamTokens);
+
+        CaseData caseData = buildCaseData(APPEAL_RECEIVED);
+        caseData.setRegion(getRegionalProcessingCenter().getName());
+        caseData.setRegionalProcessingCenter(getRegionalProcessingCenter());
+
+        verify(createCcdService, times(1))
+            .create(eq(caseData), eq(idamTokens));
+    }
+
+    @Test
+    public void shouldNotAddRegionalProcessingCenterIfDisabled() {
+        ReflectionTestUtils.setField(ccdCasesSender, "lookupRpcByVenueId", true);
         ccdCasesSender.sendCreateCcdCases(buildCaseData(APPEAL_RECEIVED), idamTokens);
 
         CaseData caseData = buildCaseData(APPEAL_RECEIVED);
 
+        verifyZeroInteractions(regionalProcessingCenterService);
         verify(createCcdService, times(1))
             .create(eq(caseData), eq(idamTokens));
     }
@@ -119,10 +152,14 @@ public class CcdCasesSenderTest {
     @Parameters({"APPEAL_RECEIVED", "RESPONSE_RECEIVED", "HEARING_BOOKED", "HEARING_POSTPONED", "APPEAL_LAPSED",
         "APPEAL_WITHDRAWN", "HEARING_ADJOURNED", "APPEAL_DORMANT"})
     public void shouldUpdateCcdGivenThereIsAnEventChange(GapsEvent gapsEvent) throws Exception {
+        when(regionalProcessingCenterService.getByScReferenceCode(anyString()))
+            .thenReturn(getRegionalProcessingCenter());
         ccdCasesSender.sendUpdateCcdCases(buildCaseData(gapsEvent),
             getCaseDetails(CASE_DETAILS_JSON), idamTokens);
 
         CaseData caseData = buildCaseData(gapsEvent);
+        caseData.setRegion(getRegionalProcessingCenter().getName());
+        caseData.setRegionalProcessingCenter(getRegionalProcessingCenter());
         verify(updateCcdService, times(1))
             .update(eq(caseData), anyLong(), eq(gapsEvent.getType()), eq(idamTokens));
     }
@@ -215,9 +252,11 @@ public class CcdCasesSenderTest {
     @Test
     public void shouldAddExistingHearingDetailsToTheCaseIfItsMissingInComingGaps2Xml() throws Exception {
 
-        List<Hearing> hearings = buildHearings();
+        when(regionalProcessingCenterService.getByScReferenceCode("SC068/17/00011"))
+            .thenReturn(getRegionalProcessingCenter());
+
         CaseData caseData = buildCaseData(RESPONSE_RECEIVED);
-        caseData.setHearings(hearings);
+        caseData.setHearings(buildHearings());
         ArgumentCaptor<CaseData> caseDataArgumentCaptor = ArgumentCaptor.forClass(CaseData.class);
 
         CaseDetails existingCaseDetails = getCaseDetails(CASE_DETAILS_WITH_HEARINGS_JSON);
@@ -256,6 +295,10 @@ public class CcdCasesSenderTest {
 
     @Test
     public void shouldAddExistingNewHearingDetailsFromCcdToCaseWhenNoHearingDetailsinGaps2Xml() throws Exception {
+
+        when(regionalProcessingCenterService.getByScReferenceCode("SC068/17/00011"))
+            .thenReturn(getRegionalProcessingCenter());
+
         CaseData caseData = buildCaseData(RESPONSE_RECEIVED);
         ArgumentCaptor<CaseData> caseDataArgumentCaptor = ArgumentCaptor.forClass(CaseData.class);
 
@@ -269,6 +312,105 @@ public class CcdCasesSenderTest {
         assertThat(caseDataArgumentCaptor.getValue().getHearings().size(), equalTo(2));
         assertThat(caseDataArgumentCaptor.getValue().getHearings().get(0).getValue().getHearingDateTime(),
             equalTo("2017-05-2410:00"));
+
+
+    }
+
+    @Test
+    public void shouldAddRegionalProcessingCenterForANewCaseInCcdFromGaps2() {
+        RegionalProcessingCenter regionalProcessingCenter = getRegionalProcessingCenter();
+        CaseData caseData = buildCaseData(RESPONSE_RECEIVED);
+        when(regionalProcessingCenterService.getByScReferenceCode("SC068/17/00011"))
+            .thenReturn(regionalProcessingCenter);
+        ArgumentCaptor<CaseData> caseDataArgumentCaptor = ArgumentCaptor.forClass(CaseData.class);
+
+        ccdCasesSender.sendCreateCcdCases(caseData, idamTokens);
+
+        verify(createCcdService).create(caseDataArgumentCaptor.capture(), eq(idamTokens));
+
+        assertThat(caseDataArgumentCaptor.getValue().getRegion(), equalTo(regionalProcessingCenter.getName()));
+        assertThat(caseDataArgumentCaptor.getValue().getRegionalProcessingCenter(), equalTo(regionalProcessingCenter));
+
+    }
+
+
+    @Test
+    public void shouldAddRegionalProcessingCenterForAnExistingCaseIfItsNotAlreadyPresentInCcd() throws Exception {
+        RegionalProcessingCenter regionalProcessingCenter = getRegionalProcessingCenter();
+        ArgumentCaptor<CaseData> caseDataArgumentCaptor = ArgumentCaptor.forClass(CaseData.class);
+
+        CaseData caseData = buildCaseData(RESPONSE_RECEIVED);
+        when(regionalProcessingCenterService.getByScReferenceCode("SC068/17/00011"))
+            .thenReturn(regionalProcessingCenter);
+
+        CaseDetails existingCaseDetails = getCaseDetails(CASE_DETAILS_WITH_HEARINGS_JSON);
+
+        ccdCasesSender.sendUpdateCcdCases(caseData, existingCaseDetails, idamTokens);
+
+        verify(updateCcdService).update(caseDataArgumentCaptor.capture(),
+            eq(existingCaseDetails.getId()), eq(caseData.getLatestEventType()), eq(idamTokens));
+
+        assertThat(caseDataArgumentCaptor.getValue().getRegionalProcessingCenter(), equalTo(regionalProcessingCenter));
+        assertThat(caseDataArgumentCaptor.getValue().getRegion(), equalTo(regionalProcessingCenter.getName()));
+    }
+
+    @Test
+    public void shouldNotAddRegionalProcessingCenterForAnExistingCaseIfItsNotAlreadyPresentInCcdIfDisabled()
+        throws Exception {
+        ReflectionTestUtils.setField(ccdCasesSender, "lookupRpcByVenueId", true);
+
+        RegionalProcessingCenter regionalProcessingCenter = getRegionalProcessingCenter();
+        ArgumentCaptor<CaseData> caseDataArgumentCaptor = ArgumentCaptor.forClass(CaseData.class);
+
+        CaseData caseData = buildCaseData(RESPONSE_RECEIVED);
+        when(regionalProcessingCenterService.getByScReferenceCode("SC068/17/00011"))
+            .thenReturn(regionalProcessingCenter);
+
+        CaseDetails existingCaseDetails = getCaseDetails(CASE_DETAILS_WITH_HEARINGS_JSON);
+
+        ccdCasesSender.sendUpdateCcdCases(caseData, existingCaseDetails, idamTokens);
+
+        verify(updateCcdService).update(caseDataArgumentCaptor.capture(),
+            eq(existingCaseDetails.getId()), eq(caseData.getLatestEventType()), eq(idamTokens));
+
+        verifyZeroInteractions(regionalProcessingCenterService);
+    }
+
+    @Test
+    public void shouldNotAddRegionalProcessingCenterForAnExistingCaseIfItsAlreadyPresent() throws Exception {
+        RegionalProcessingCenter regionalProcessingCenter = getRegionalProcessingCenter();
+        ArgumentCaptor<CaseData> caseDataArgumentCaptor = ArgumentCaptor.forClass(CaseData.class);
+
+        CaseData caseData = buildCaseDataForEventAndCaseReference(RESPONSE_RECEIVED, "SC068/17/00013");
+        when(regionalProcessingCenterService.getByScReferenceCode("SC068/17/00013"))
+            .thenReturn(regionalProcessingCenter);
+
+        CaseDetails existingCaseDetails = getCaseDetails(CASE_DETAILS_WITH_NO_HEARINGS_JSON);
+
+        ccdCasesSender.sendUpdateCcdCases(caseData, existingCaseDetails, idamTokens);
+
+        verify(updateCcdService).update(caseDataArgumentCaptor.capture(),
+            eq(existingCaseDetails.getId()), eq(caseData.getLatestEventType()), eq(idamTokens));
+        verify(regionalProcessingCenterService, never()).getByScReferenceCode("SC068/17/00013");
+
+    }
+
+    @Test
+    public void shouldAddRegionalProcessingCenterOnlyIfItsPresent() throws Exception {
+        ArgumentCaptor<CaseData> caseDataArgumentCaptor = ArgumentCaptor.forClass(CaseData.class);
+
+        CaseData caseData = buildCaseData(RESPONSE_RECEIVED);
+        when(regionalProcessingCenterService.getByScReferenceCode("SC068/17/00011"))
+            .thenReturn(null);
+
+        CaseDetails existingCaseDetails = getCaseDetails(CASE_DETAILS_WITH_HEARINGS_JSON);
+
+        ccdCasesSender.sendUpdateCcdCases(caseData, existingCaseDetails, idamTokens);
+
+        verify(updateCcdService).update(caseDataArgumentCaptor.capture(),
+            eq(existingCaseDetails.getId()), eq(caseData.getLatestEventType()), eq(idamTokens));
+
+        assertThat(caseDataArgumentCaptor.getValue().getRegionalProcessingCenter(), equalTo(null));
 
 
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/CaseDataBuilderTest.java
@@ -2,15 +2,15 @@ package uk.gov.hmcts.reform.sscs.services.mapper;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static uk.gov.hmcts.reform.sscs.services.mapper.CaseDataBuilder.NO;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
@@ -20,11 +20,13 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.sscs.models.GapsEvent;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
+import uk.gov.hmcts.reform.sscs.models.refdata.RegionalProcessingCenter;
 import uk.gov.hmcts.reform.sscs.models.refdata.VenueDetails;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.BenefitType;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.Hearing;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.subscriptions.Subscriptions;
 import uk.gov.hmcts.reform.sscs.services.refdata.ReferenceDataService;
+import uk.gov.hmcts.reform.sscs.services.refdata.RegionalProcessingCenterService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CaseDataBuilderTest extends CaseDataBuilderBase {
@@ -33,21 +35,27 @@ public class CaseDataBuilderTest extends CaseDataBuilderBase {
     private ReferenceDataService refDataService;
     @Mock
     private CaseDataEventBuilder caseDataEventBuilder;
+    @Mock
+    private RegionalProcessingCenterService regionalProcessingCentreService;
     private CaseDataBuilder caseDataBuilder;
     private AppealCase appeal;
 
     @Before
     public void setUp() {
+        createAppealCase(getHearing());
+    }
+
+    private void createAppealCase(List<uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing> hearings) {
         appeal = AppealCase.builder()
             .appealCaseCaseCodeId("1")
             .majorStatus(Collections.singletonList(
                 super.buildMajorStatusGivenStatusAndDate(GapsEvent.APPEAL_RECEIVED.getStatus(), APPEAL_RECEIVED_DATE)
             ))
-            .hearing(getHearing())
+            .hearing(hearings)
             .minorStatus(Collections.singletonList(
                 super.buildMinorStatusGivenIdAndDate("26", HEARING_POSTPONED_DATE)))
             .build();
-        caseDataBuilder = new CaseDataBuilder(refDataService, caseDataEventBuilder);
+        caseDataBuilder = new CaseDataBuilder(refDataService, caseDataEventBuilder, regionalProcessingCentreService);
     }
 
     public List<uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing> getHearing() {
@@ -125,5 +133,52 @@ public class CaseDataBuilderTest extends CaseDataBuilderBase {
         List<Hearing> hearingList = caseDataBuilder.buildHearings(appeal);
 
         assertEquals("id", hearingList.get(0).getValue().getHearingId());
+    }
+
+    @Test
+    public void shouldBuildRegionalProcessingCentre() {
+        RegionalProcessingCenter expectedRegionalProcessingCentre = RegionalProcessingCenter.builder().build();
+        when(regionalProcessingCentreService.getByVenueId("venue")).thenReturn(expectedRegionalProcessingCentre);
+        RegionalProcessingCenter regionalProcessingCentre = caseDataBuilder.buildRegionalProcessingCentre(appeal);
+
+        assertThat(regionalProcessingCentre, is(expectedRegionalProcessingCentre));
+    }
+
+    @Test
+    public void shouldReturnNullRemoteProcessingCentreIfNoHearings() {
+        createAppealCase(null);
+        RegionalProcessingCenter regionalProcessingCentre = caseDataBuilder.buildRegionalProcessingCentre(appeal);
+
+        assertThat(regionalProcessingCentre, is(nullValue()));
+    }
+
+    @Test
+    public void shouldBuildRegionalProcessingCentreFromLatestHearing() {
+        uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing hearing1 =
+            uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing.builder()
+                .venueId("venue1")
+                .sessionDate("2017-05-24T00:00:00+01:00")
+                .appealTime("2017-05-24T10:30:00+01:00")
+                .build();
+        uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing hearing2 =
+            uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing.builder()
+                .venueId("venue2")
+                .sessionDate("2017-05-26T00:00:00+01:00")
+                .appealTime("2017-05-26T11:30:00+01:00")
+                .build();
+        uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing hearing3 =
+            uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.Hearing.builder()
+                .venueId("venue3")
+                .sessionDate("2017-05-26T00:00:00+01:00")
+                .appealTime("2017-05-26T10:30:00+01:00")
+                .build();
+
+        createAppealCase(Arrays.asList(hearing1, hearing2, hearing3));
+
+        RegionalProcessingCenter expectedRegionalProcessingCentre = RegionalProcessingCenter.builder().build();
+        when(regionalProcessingCentreService.getByVenueId("venue2")).thenReturn(expectedRegionalProcessingCentre);
+        RegionalProcessingCenter regionalProcessingCentre = caseDataBuilder.buildRegionalProcessingCentre(appeal);
+
+        assertThat(regionalProcessingCentre, is(expectedRegionalProcessingCentre));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/TransformAppealCaseToCaseDataTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/TransformAppealCaseToCaseDataTest.java
@@ -1,9 +1,7 @@
 package uk.gov.hmcts.reform.sscs.services.mapper;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -12,6 +10,7 @@ import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.reform.sscs.models.deserialize.gaps2.AppealCase;
 import uk.gov.hmcts.reform.sscs.models.refdata.RegionalProcessingCenter;
 import uk.gov.hmcts.reform.sscs.models.serialize.ccd.CaseData;
@@ -29,6 +28,7 @@ public class TransformAppealCaseToCaseDataTest {
             new CaseDataBuilder(referenceDataService, caseDataEventBuilder, regionalProcessingCenterService);
         TransformAppealCaseToCaseData transformAppealCaseToCaseData =
             new TransformAppealCaseToCaseData(caseDataBuilder);
+        ReflectionTestUtils.setField(transformAppealCaseToCaseData, "lookupRpcByVenueId", true);
 
         String expectedRegionName = "region-name";
         RegionalProcessingCenter expectedRegionalProcessingCentre = RegionalProcessingCenter.builder()
@@ -44,7 +44,7 @@ public class TransformAppealCaseToCaseDataTest {
         assertTrue("appealNumber length is not 10 digits", appealNumber.length() == 10);
         assertEquals("Appeal references are mapped (SC Reference)", "SC068/17/00013", caseData.getCaseReference());
         assertEquals("Appeal references are mapped (CCD ID)", "1111222233334444", caseData.getCcdCaseId());
-        assertThat(caseData.getRegionalProcessingCenter(), is(expectedRegionalProcesingCentre));
+        assertThat(caseData.getRegionalProcessingCenter(), is(expectedRegionalProcessingCentre));
         assertThat(caseData.getRegion(), is(expectedRegionName));
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/TransformAppealCaseToCaseDataTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/mapper/TransformAppealCaseToCaseDataTest.java
@@ -31,10 +31,10 @@ public class TransformAppealCaseToCaseDataTest {
             new TransformAppealCaseToCaseData(caseDataBuilder);
 
         String expectedRegionName = "region-name";
-        RegionalProcessingCenter expectedRegionalProcesingCentre = RegionalProcessingCenter.builder()
+        RegionalProcessingCenter expectedRegionalProcessingCentre = RegionalProcessingCenter.builder()
             .name(expectedRegionName)
             .build();
-        when(regionalProcessingCenterService.getByVenueId("68")).thenReturn(expectedRegionalProcesingCentre);
+        when(regionalProcessingCenterService.getByVenueId("68")).thenReturn(expectedRegionalProcessingCentre);
 
         AppealCase appealCase = getAppealCase();
 
@@ -42,7 +42,6 @@ public class TransformAppealCaseToCaseDataTest {
 
         String appealNumber = caseData.getSubscriptions().getAppellantSubscription().getTya();
         assertTrue("appealNumber length is not 10 digits", appealNumber.length() == 10);
-
         assertEquals("Appeal references are mapped (SC Reference)", "SC068/17/00013", caseData.getCaseReference());
         assertEquals("Appeal references are mapped (CCD ID)", "1111222233334444", caseData.getCcdCaseId());
         assertThat(caseData.getRegionalProcessingCenter(), is(expectedRegionalProcesingCentre));

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/refdata/AirLookupServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/refdata/AirLookupServiceTest.java
@@ -1,0 +1,77 @@
+package uk.gov.hmcts.reform.sscs.services.refdata;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class AirLookupServiceTest {
+    AirLookupService airLookupService;
+
+    @Before
+    public void setUp() {
+        airLookupService = new AirLookupService();
+        airLookupService.init();
+    }
+
+    @Test
+    public void lookupPostcode() {
+        String adminGroup = airLookupService.lookupRegionalCentre("BR3 8JK");
+        assertEquals("Sutton", adminGroup);
+    }
+
+    @Test
+    public void lookupPostcodeLowerCase() {
+        String adminGroup = airLookupService.lookupRegionalCentre("br3 8JK");
+        assertEquals("Sutton", adminGroup);
+    }
+
+    @Test
+    public void lookupPostcodeNotThere() {
+        String adminGroup = airLookupService.lookupRegionalCentre("aa1 1aa");
+        assertEquals(null, adminGroup);
+    }
+
+    @Test
+    public void lookupLastValue() {
+        String adminGroup = airLookupService.lookupRegionalCentre("ze3 4gh");
+        assertEquals("Glasgow", adminGroup);
+    }
+
+    @Test
+    public void lookupFirstValue() {
+        String adminGroup = airLookupService.lookupRegionalCentre("ab1 2gh");
+        assertEquals("Glasgow", adminGroup);
+    }
+
+    @Test
+    public void lookupShortPostcode() {
+        String adminGroup = airLookupService.lookupRegionalCentre("l2 1RT");
+        assertEquals("Liverpool", adminGroup);
+    }
+
+    @Test
+    public void lookupLongPostcode() {
+        String adminGroup = airLookupService.lookupRegionalCentre("HP27 1RT");
+        assertEquals("Birmingham", adminGroup);
+    }
+
+    @Test
+    public void lookupShortPostcodeNoSpace() {
+        String adminGroup = airLookupService.lookupRegionalCentre("l21RT");
+        assertEquals("Liverpool", adminGroup);
+    }
+
+
+    @Test
+    public void lookupLongPostcodeNoSpace() {
+        String adminGroup = airLookupService.lookupRegionalCentre("HP271RT");
+        assertEquals("Birmingham", adminGroup);
+    }
+
+    @Test
+    public void lookupLongPostcodeOutcode() {
+        String adminGroup = airLookupService.lookupRegionalCentre("HP27");
+        assertEquals("Birmingham", adminGroup);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/refdata/RegionalProcessingCenterServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/refdata/RegionalProcessingCenterServiceTest.java
@@ -2,13 +2,21 @@ package uk.gov.hmcts.reform.sscs.services.refdata;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
 
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.sscs.models.refdata.RegionalProcessingCenter;
 
+@RunWith(MockitoJUnitRunner.class)
 public class RegionalProcessingCenterServiceTest {
+
+    @Mock
+    private AirLookupService airLookupService;
 
     private static final String SSCS_LIVERPOOL = "SSCS Liverpool";
 
@@ -16,7 +24,7 @@ public class RegionalProcessingCenterServiceTest {
 
     @Before
     public void setUp() throws Exception {
-        regionalProcessingCenterService = new RegionalProcessingCenterService();
+        regionalProcessingCenterService = new RegionalProcessingCenterService(airLookupService);
     }
 
     @Test
@@ -48,6 +56,17 @@ public class RegionalProcessingCenterServiceTest {
 
         String leedsVenueId = "10";
         RegionalProcessingCenter rpc = regionalProcessingCenterService.getByVenueId(leedsVenueId);
+
+        assertThat(rpc.getName(), equalTo("LEEDS"));
+    }
+
+    @Test
+    public void getRegionalProcessingCentreFromPostcode() {
+        regionalProcessingCenterService.init();
+
+        String somePostcode = "AB1 1AB";
+        when(airLookupService.lookupRegionalCentre(somePostcode)).thenReturn("Leeds");
+        RegionalProcessingCenter rpc = regionalProcessingCenterService.getByPostcode(somePostcode);
 
         assertThat(rpc.getName(), equalTo("LEEDS"));
     }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/refdata/RegionalProcessingCenterServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/refdata/RegionalProcessingCenterServiceTest.java
@@ -19,22 +19,6 @@ public class RegionalProcessingCenterServiceTest {
         regionalProcessingCenterService = new RegionalProcessingCenterService();
     }
 
-
-    @Test
-    public void givenVenuesCvsFile_shouldLoadSccodeToRpcMap() {
-        //When
-        regionalProcessingCenterService.init();
-
-        //Then
-        Map<String, String> sccodeRegionalProcessingCentermap
-                = regionalProcessingCenterService.getSccodeRegionalProcessingCentermap();
-        assertThat(sccodeRegionalProcessingCentermap.size(), equalTo(245));
-        assertThat(sccodeRegionalProcessingCentermap.get("SC038"), equalTo("SSCS Birmingham"));
-        assertThat(sccodeRegionalProcessingCentermap.get("SC001"), equalTo("SSCS Leeds"));
-        assertThat(sccodeRegionalProcessingCentermap.get("SC293"), equalTo("SSCS Cardiff"));
-    }
-
-
     @Test
     public void givenRpcMetaData_shouldLoadRpcMetadataToMap() {
         //When
@@ -59,50 +43,12 @@ public class RegionalProcessingCenterServiceTest {
     }
 
     @Test
-    public void shouldReturnRegionalProcessingCenterForGivenAppealReferenceNumber() {
-        //Given
-        String referenceNumber = "SC274/13/00010";
+    public void getRegionalProcessingCentreFromVenueId() {
         regionalProcessingCenterService.init();
 
-        //When
-        RegionalProcessingCenter regionalProcessingCenter =
-                regionalProcessingCenterService.getByScReferenceCode(referenceNumber);
+        String leedsVenueId = "10";
+        RegionalProcessingCenter rpc = regionalProcessingCenterService.getByVenueId(leedsVenueId);
 
-        //Then
-        assertThat(regionalProcessingCenter.getName(), equalTo("LIVERPOOL"));
-        assertThat(regionalProcessingCenter.getAddress1(), equalTo("HM Courts & Tribunals Service"));
-        assertThat(regionalProcessingCenter.getAddress2(), equalTo("Social Security & Child Support Appeals"));
-        assertThat(regionalProcessingCenter.getAddress3(), equalTo("Prudential Buildings"));
-        assertThat(regionalProcessingCenter.getAddress4(), equalTo("36 Dale Street"));
-        assertThat(regionalProcessingCenter.getCity(), equalTo("LIVERPOOL"));
-        assertThat(regionalProcessingCenter.getPostcode(), equalTo("L2 5UZ"));
-        assertThat(regionalProcessingCenter.getPhoneNumber(), equalTo("0300 123 1142"));
-        assertThat(regionalProcessingCenter.getFaxNumber(), equalTo("0870 324 0109"));
-
-
-    }
-
-    @Test
-    public void shouldReturnBirminghamRegionalProcessingCenterAsDefault() {
-
-        //Given
-        String referenceNumber = "SC000/13/00010";
-        regionalProcessingCenterService.init();
-
-        //When
-        RegionalProcessingCenter regionalProcessingCenter =
-                regionalProcessingCenterService.getByScReferenceCode(referenceNumber);
-
-        //Then
-        assertThat(regionalProcessingCenter.getName(), equalTo("BIRMINGHAM"));
-        assertThat(regionalProcessingCenter.getAddress1(), equalTo("HM Courts & Tribunals Service"));
-        assertThat(regionalProcessingCenter.getAddress2(), equalTo("Social Security & Child Support Appeals"));
-        assertThat(regionalProcessingCenter.getAddress3(), equalTo("Administrative Support Centre"));
-        assertThat(regionalProcessingCenter.getAddress4(), equalTo("PO Box 14620"));
-        assertThat(regionalProcessingCenter.getCity(), equalTo("BIRMINGHAM"));
-        assertThat(regionalProcessingCenter.getPostcode(), equalTo("B16 6FR"));
-        assertThat(regionalProcessingCenter.getPhoneNumber(), equalTo("0300 123 1142"));
-        assertThat(regionalProcessingCenter.getFaxNumber(), equalTo("0126 434 7983"));
-
+        assertThat(rpc.getName(), equalTo("LEEDS"));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/refdata/RegionalProcessingCenterServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/refdata/RegionalProcessingCenterServiceTest.java
@@ -28,6 +28,20 @@ public class RegionalProcessingCenterServiceTest {
     }
 
     @Test
+    public void givenVenuesCvsFile_shouldLoadSccodeToRpcMap() {
+        //When
+        regionalProcessingCenterService.init();
+
+        //Then
+        Map<String, String> sccodeRegionalProcessingCentermap
+            = regionalProcessingCenterService.getSccodeRegionalProcessingCentermap();
+        assertThat(sccodeRegionalProcessingCentermap.size(), equalTo(245));
+        assertThat(sccodeRegionalProcessingCentermap.get("SC038"), equalTo("SSCS Birmingham"));
+        assertThat(sccodeRegionalProcessingCentermap.get("SC001"), equalTo("SSCS Leeds"));
+        assertThat(sccodeRegionalProcessingCentermap.get("SC293"), equalTo("SSCS Cardiff"));
+    }
+
+    @Test
     public void givenRpcMetaData_shouldLoadRpcMetadataToMap() {
         //When
         regionalProcessingCenterService.init();
@@ -47,6 +61,54 @@ public class RegionalProcessingCenterServiceTest {
         assertThat(regionalProcessingCenter.getPostcode(), equalTo("L2 5UZ"));
         assertThat(regionalProcessingCenter.getPhoneNumber(), equalTo("0300 123 1142"));
         assertThat(regionalProcessingCenter.getFaxNumber(), equalTo("0870 324 0109"));
+
+    }
+
+    @Test
+    public void shouldReturnRegionalProcessingCenterForGivenAppealReferenceNumber() {
+        //Given
+        String referenceNumber = "SC274/13/00010";
+        regionalProcessingCenterService.init();
+
+        //When
+        RegionalProcessingCenter regionalProcessingCenter =
+            regionalProcessingCenterService.getByScReferenceCode(referenceNumber);
+
+        //Then
+        assertThat(regionalProcessingCenter.getName(), equalTo("LIVERPOOL"));
+        assertThat(regionalProcessingCenter.getAddress1(), equalTo("HM Courts & Tribunals Service"));
+        assertThat(regionalProcessingCenter.getAddress2(), equalTo("Social Security & Child Support Appeals"));
+        assertThat(regionalProcessingCenter.getAddress3(), equalTo("Prudential Buildings"));
+        assertThat(regionalProcessingCenter.getAddress4(), equalTo("36 Dale Street"));
+        assertThat(regionalProcessingCenter.getCity(), equalTo("LIVERPOOL"));
+        assertThat(regionalProcessingCenter.getPostcode(), equalTo("L2 5UZ"));
+        assertThat(regionalProcessingCenter.getPhoneNumber(), equalTo("0300 123 1142"));
+        assertThat(regionalProcessingCenter.getFaxNumber(), equalTo("0870 324 0109"));
+
+
+    }
+
+    @Test
+    public void shouldReturnBirminghamRegionalProcessingCenterAsDefault() {
+
+        //Given
+        String referenceNumber = "SC000/13/00010";
+        regionalProcessingCenterService.init();
+
+        //When
+        RegionalProcessingCenter regionalProcessingCenter =
+            regionalProcessingCenterService.getByScReferenceCode(referenceNumber);
+
+        //Then
+        assertThat(regionalProcessingCenter.getName(), equalTo("BIRMINGHAM"));
+        assertThat(regionalProcessingCenter.getAddress1(), equalTo("HM Courts & Tribunals Service"));
+        assertThat(regionalProcessingCenter.getAddress2(), equalTo("Social Security & Child Support Appeals"));
+        assertThat(regionalProcessingCenter.getAddress3(), equalTo("Administrative Support Centre"));
+        assertThat(regionalProcessingCenter.getAddress4(), equalTo("PO Box 14620"));
+        assertThat(regionalProcessingCenter.getCity(), equalTo("BIRMINGHAM"));
+        assertThat(regionalProcessingCenter.getPostcode(), equalTo("B16 6FR"));
+        assertThat(regionalProcessingCenter.getPhoneNumber(), equalTo("0300 123 1142"));
+        assertThat(regionalProcessingCenter.getFaxNumber(), equalTo("0126 434 7983"));
 
     }
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/SSCS-3428

We no longer want to base the RPC and region on the SC number as we
will not have one in future. Instead we already have a mapping between
the hearing venue id and RPC. If we have a hearing use this to populate
the RPC and the region. If we have multiple hearings use the latest.

**Does this PR introduce a breaking change?**

```
[ ] Yes
[x] No
```
