### PR TITLE
[PREVIEW]SSCS-4301 Prevent 'NumberFormatException' from terminating case loading

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/CaseLoaderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/CaseLoaderService.java
@@ -85,8 +85,9 @@ public class CaseLoaderService {
                 try {
                     sscsCaseDetails = searchCcdCaseService.findCaseByCaseRefOrCaseId(caseData, idamTokens);
                 } catch (NumberFormatException e) {
-                    log.info("*** case-loader *** case with SC {} and ccdID {} could not be searched for, skipping case...",
-                    caseData.getCaseReference(), caseData.getCcdCaseId());
+                    log.info("*** case-loader *** case with SC {} and ccdID {} could not be searched for,"
+                        + " skipping case...",
+                        caseData.getCaseReference(), caseData.getCcdCaseId());
                     continue;
                 }
                 

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/CaseLoaderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/CaseLoaderService.java
@@ -81,7 +81,15 @@ public class CaseLoaderService {
         log.info("*** case-loader *** file transformed to {} Cases successfully", cases.size());
         for (SscsCaseData caseData : cases) {
             if (!caseData.getAppeal().getBenefitType().getCode().equals("ERR")) {
-                SscsCaseDetails sscsCaseDetails = searchCcdCaseService.findCaseByCaseRefOrCaseId(caseData, idamTokens);
+                SscsCaseDetails sscsCaseDetails;
+                try {
+                    sscsCaseDetails = searchCcdCaseService.findCaseByCaseRefOrCaseId(caseData, idamTokens);
+                } catch (NumberFormatException e) {
+                    log.info("*** case-loader *** case with SC {} and ccdID {} could not be searched for, skipping case...",
+                    caseData.getCaseReference(), caseData.getCcdCaseId());
+                    continue;
+                }
+                
                 if (null == sscsCaseDetails) {
                     log.info("*** case-loader *** case with SC {} and ccdID {} does not exist, it will be created...",
                         caseData.getCaseReference(), caseData.getCcdCaseId());

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/CaseLoaderService.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/CaseLoaderService.java
@@ -82,6 +82,7 @@ public class CaseLoaderService {
         for (SscsCaseData caseData : cases) {
             if (!caseData.getAppeal().getBenefitType().getCode().equals("ERR")) {
                 SscsCaseDetails sscsCaseDetails;
+                
                 try {
                     sscsCaseDetails = searchCcdCaseService.findCaseByCaseRefOrCaseId(caseData, idamTokens);
                 } catch (NumberFormatException e) {
@@ -90,7 +91,7 @@ public class CaseLoaderService {
                         caseData.getCaseReference(), caseData.getCcdCaseId());
                     continue;
                 }
-                
+
                 if (null == sscsCaseDetails) {
                     log.info("*** case-loader *** case with SC {} and ccdID {} does not exist, it will be created...",
                         caseData.getCaseReference(), caseData.getCcdCaseId());
@@ -103,5 +104,4 @@ public class CaseLoaderService {
             }
         }
     }
-
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-4301


### Change description ###
Some cases in the nightly deltas have "WELSH LANGUAGE" in the case ID field which throws a Java NumberFormatException when we try and parse this in order to use it in a search.

This change makes this process more fault tolerant, catching and logging the exception before moving onto the next case delta rather than ending the whole process.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
