### PR TITLE
SSCS-7604: Stop case loader from updating the hearing type to Domiciliary

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/ccd/UpdateCcdHearingType.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/ccd/UpdateCcdHearingType.java
@@ -13,7 +13,8 @@ class UpdateCcdHearingType {
         if (StringUtils.isNotBlank(gaps2HearingType)) {
             String ccdHearingType = existingCcdCaseData.getAppeal().getHearingType();
             if (StringUtils.isNotBlank(ccdHearingType)) {
-                if (!HearingType.COR.getValue().equalsIgnoreCase(ccdHearingType)) {
+                if (!HearingType.COR.getValue().equalsIgnoreCase(ccdHearingType)
+                    && !HearingType.DOMICILIARY.getValue().equalsIgnoreCase(gaps2HearingType)) {
                     if (!gaps2HearingType.equals(ccdHearingType)) {
                         existingCcdCaseData.getAppeal().setHearingType(gaps2HearingType);
                         return true;

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/ccd/UpdateCcdHearingTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/ccd/UpdateCcdHearingTypeTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.sscs.services.ccd;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static uk.gov.hmcts.reform.sscs.ccd.domain.HearingType.*;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -29,9 +30,15 @@ public class UpdateCcdHearingTypeTest {
 
     @SuppressWarnings("PMD.UnusedPrivateMethod")
     private Object[] generateHearingTypeUpdateScenarios() {
-        SscsCaseData gapsCaseData = SscsCaseData.builder()
+        SscsCaseData gapsCaseDataOralHearingType = SscsCaseData.builder()
             .appeal(Appeal.builder()
-                .hearingType("oral")
+                .hearingType(ORAL.getValue())
+                .build())
+            .build();
+
+        SscsCaseData gapsCaseDataDomiciliaryHearingType = SscsCaseData.builder()
+            .appeal(Appeal.builder()
+                .hearingType(DOMICILIARY.getValue())
                 .build())
             .build();
 
@@ -48,13 +55,13 @@ public class UpdateCcdHearingTypeTest {
 
         SscsCaseData gapsCaseDataWithCorHearingType = SscsCaseData.builder()
             .appeal(Appeal.builder()
-                .hearingType("paper")
+                .hearingType(PAPER.getValue())
                 .build())
             .build();
 
         SscsCaseData existingCcdCase = SscsCaseData.builder()
             .appeal(Appeal.builder()
-                .hearingType("paper")
+                .hearingType(PAPER.getValue())
                 .build())
             .build();
 
@@ -71,18 +78,18 @@ public class UpdateCcdHearingTypeTest {
 
         SscsCaseData existingCcdCaseCorHearingType = SscsCaseData.builder()
             .appeal(Appeal.builder()
-                .hearingType("cor")
+                .hearingType(COR.getValue())
                 .build())
             .build();
-
-
 
         return new Object[]{
             new Object[]{gapsCaseDataWithNullHearingType, existingCcdCase, false, "paper"},
             new Object[]{gapsCaseDataWithMoreEmptyHearingType, existingCcdCase, false, "paper"},
-            new Object[]{gapsCaseData, existingCcdCase, true, "oral"},
-            new Object[]{gapsCaseData, existingCcdCaseWithNullHearingType, true, "oral"},
-            new Object[]{gapsCaseData, existingCcdCaseWithEmptyHearingType, true, "oral"},
+            // SSCS-7604 - Do not update hearing type to Domiciliary
+            new Object[]{gapsCaseDataDomiciliaryHearingType, existingCcdCase, false, "paper"},
+            new Object[]{gapsCaseDataOralHearingType, existingCcdCase, true, "oral"},
+            new Object[]{gapsCaseDataOralHearingType, existingCcdCaseWithNullHearingType, true, "oral"},
+            new Object[]{gapsCaseDataOralHearingType, existingCcdCaseWithEmptyHearingType, true, "oral"},
             new Object[]{gapsCaseDataWithCorHearingType, existingCcdCaseCorHearingType, false, "cor"}
         };
     }


### PR DESCRIPTION
At the moment the business is amending and scheduling hearings as Domiciliary (within GAPS) and this causes issues downstream, when it then comes as an update to us. The change in hearing type then causes MYA and TYA to not work / display an error message, as both services haven’t been built to handle that hearing type. This ticket is to provide a quick fix (as due to COVID cases are marked as domiciliary – as part of the push to have telephone hearings), to stop caseloader updating cases to a hearing type of “Domiciliary”.

As caseloader
When I get an update for a case
And the update contains a hearing type update to “Domiciliary”
(TRIBUNAL_TYPE_ID – 3)
Then there the hearing type isn’t updated
But other details of the case are (if there are other data changes)

