### PR TITLE
CVE dependency patches and minors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -201,6 +201,7 @@ configurations {
 
 dependencyManagement {
   dependencies {
+    // CVE-2022-25857, CVE-2022-38749, CVE-2022-38750, CVE-2022-38751, CVE-2022-38752, CVE-2022-41854
     dependencySet(group: 'org.yaml', version: '1.33') {
       entry 'snakeyaml'
     }
@@ -241,8 +242,6 @@ dependencies {
   implementation  group: 'com.github.hmcts', name: 'sscs-common', version: '5.3.4'
 
   implementation 'com.github.mwiede:jsch:0.2.11'
-
-//  implementation  group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.70'
 
   implementation  group: 'org.json', name: 'json', version: '20240303'
 

--- a/build.gradle
+++ b/build.gradle
@@ -199,6 +199,14 @@ configurations {
   e2eImplementation.extendsFrom(testImplementation )
 }
 
+dependencyManagement {
+  dependencies {
+    dependencySet(group: 'org.yaml', version: '1.33') {
+      entry 'snakeyaml'
+    }
+  }
+}
+
 dependencies {
   implementation  group: 'org.springframework.boot', name: 'spring-boot-starter-batch'
   testImplementation  group: 'org.springframework.boot', name: 'spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -219,7 +219,7 @@ dependencies {
   implementation  group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
   implementation  group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
   implementation  group: 'org.springframework', name: 'spring-context-support'
-  implementation  ('org.springframework.cloud:spring-cloud-starter-openfeign:3.1.8')
+  implementation  ('org.springframework.cloud:spring-cloud-starter-openfeign:3.1.9')
 
   // https://mvnrepository.com/artifact/commons-lang/commons-lang
   implementation 'commons-lang:commons-lang:2.6'
@@ -236,7 +236,7 @@ dependencies {
 
   implementation 'com.github.mwiede:jsch:0.2.11'
 
-  implementation  group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.70'
+//  implementation  group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.70'
 
   implementation  group: 'org.json', name: 'json', version: '20240303'
 

--- a/build.gradle
+++ b/build.gradle
@@ -204,6 +204,12 @@ dependencyManagement {
     dependencySet(group: 'org.yaml', version: '1.33') {
       entry 'snakeyaml'
     }
+
+    //CVE-2023-6378, CVE-2023-6481
+    dependencySet(group: 'ch.qos.logback', version: '1.2.13') {
+      entry 'logback-core'
+      entry 'logback-classic'
+    }
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id "io.spring.dependency-management" version "1.1.3"
-  id 'org.springframework.boot' version '2.7.14'
+  id 'org.springframework.boot' version '2.7.18'
   id 'uk.gov.hmcts.java' version '0.12.43'
   id 'com.github.ben-manes.versions' version '0.46.0'
   id 'org.sonarqube' version '4.3.0.3225'

--- a/build.gradle
+++ b/build.gradle
@@ -230,7 +230,7 @@ dependencies {
 
   implementation  group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.70'
 
-  implementation  group: 'org.json', name: 'json', version: '20230618'
+  implementation  group: 'org.json', name: 'json', version: '20240303'
 
   implementation  group: 'commons-io', name: 'commons-io', version: '2.11.0'
   implementation  group: 'org.elasticsearch', name: 'elasticsearch', version: '7.17.10'

--- a/build.gradle
+++ b/build.gradle
@@ -238,12 +238,12 @@ dependencies {
   implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
   implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
 
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core'
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations'
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind'
-  implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor'
-  implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv'
-  implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.16.0'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.16.0'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.16.0'
+  implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: '2.16.0'
+  implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: '2.16.0'
+  implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names', version: '2.16.0'
 
   testImplementation  group: 'net.javacrumbs.json-unit', name: 'json-unit-fluent', version: '2.28.0'
   testImplementation  group: 'net.javacrumbs.json-unit', name: 'json-unit', version: '2.28.0'

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -2,7 +2,5 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until = "2024-04-01">
     <cve>CVE-2022-1471</cve>
-    <cve>CVE-2023-6378</cve>
-    <cve>CVE-2023-6481</cve>
   </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -4,6 +4,5 @@
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2023-6378</cve>
     <cve>CVE-2023-6481</cve>
-    <cve>CVE-2023-34042</cve>
   </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -2,7 +2,6 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until = "2024-04-01">
     <cve>CVE-2022-1471</cve>
-    <cve>CVE-2023-34055</cve>
     <cve>CVE-2023-6378</cve>
     <cve>CVE-2023-6481</cve>
     <cve>CVE-2023-34042</cve>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until = "2024-04-01">
-    <cve>CVE-2023-5072</cve>
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2022-25857</cve>
     <cve>CVE-2022-38749</cve>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until = "2024-04-01">
-    <cve>CVE-2023-35116</cve>
     <cve>CVE-2023-5072</cve>
     <cve>CVE-2022-1471</cve>
     <cve>CVE-2022-25857</cve>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -2,12 +2,6 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until = "2024-04-01">
     <cve>CVE-2022-1471</cve>
-    <cve>CVE-2022-25857</cve>
-    <cve>CVE-2022-38749</cve>
-    <cve>CVE-2022-38750</cve>
-    <cve>CVE-2022-38751</cve>
-    <cve>CVE-2022-38752</cve>
-    <cve>CVE-2022-41854</cve>
     <cve>CVE-2023-33202</cve>
     <cve>CVE-2023-34055</cve>
     <cve>CVE-2023-6378</cve>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -2,7 +2,6 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until = "2024-04-01">
     <cve>CVE-2022-1471</cve>
-    <cve>CVE-2023-33202</cve>
     <cve>CVE-2023-34055</cve>
     <cve>CVE-2023-6378</cve>
     <cve>CVE-2023-6481</cve>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/SSCSCI-795

### Change description ###

CVE-2023-35116
Added version 2.16.0 to existing com.fasterxml.jackson dependencies

CVE-2023-5072
Bumped the existing dependency to latest version

CVE-2022-1471, CVE-2022-25857, CVE-2022-38749, CVE-2022-38750, CVE-2022-38751, CVE-2022-38752, CVE-2022-41854
Upgrading snakeyaml to recommended version (2.0) is a major, so added a new dependency to upgrade to version 1.33, this leaves only CVE-2022-1471.

CVE-2023-33202
org.bouncycastle:bcprov-jdk15on doesn't have the recommended 1.73 version and has moved to bcpkix-jdk18on. Merged renovate PR [Update Spring All #1408](https://github.com/hmcts/sscs-case-loader/pull/1408). That patched existing dependency of org.springframework.cloud:spring-cloud-starter-openfeign to version 3.1.9 and that uses version 1.73 of bcpkix-jdk18on.

CVE-2023-34055
Merged renovate PR [Update Spring All #1408](https://github.com/hmcts/sscs-case-loader/pull/1408). This patched spring-boot to recommended 2.7.18

CVE-2023-34042
org.springframework.security:spring-security-crypto is a transitive dependency and patching spring-boot to 2.7.18 fixes this CVE

CVE-2023-6378, CVE-2023-6481
Added new dependency set as existing dependency upgrades didn't fix the CVEs.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
