### PR TITLE
SSCSCI-1868: migrate from JitPack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -252,7 +252,7 @@ dependencies {
   implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '4.9.1.1'
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '7.4'
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.1.9'
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: 'd9f7b6d'
+  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '6.3.3'
   implementation group: 'com.github.mwiede', name: 'jsch', version: '0.2.11'
 
   implementation  group: 'org.json', name: 'json', version: '20240303'


### PR DESCRIPTION
### Jira link

See [SSCSCI-1868](https://tools.hmcts.net/jira/browse/SSCSCI-1868)

### Change description

#### Migrating from JitPack to Azure DevOps Artifacts

- Removed JitPack.
- Updated `io.freefair.lombok` version `8.1.0` -> `8.13.1`
- Java bump to 21

#### HMCTS repos used in tribunals
| Name | Published to | Change |
| --- | --- | --- |
| [uk.gov.hmcts.java](https://github.com/hmcts/rse-gradle-java-plugin) | Maven | `0.12.43` -> `0.12.66` |
| [com.github.hmcts:service-auth-provider-java-client](https://github.com/hmcts/service-auth-provider-java-client) | Azure Artifacts |   `4.0.3` -> `4.1.2`  |
| [com.github.hmcts:idam-java-client](https://github.com/hmcts/idam-java-client) | Azure Artifacts |  `2.1.1` -> `2.1.2`   |
| [com.github.hmcts:ccd-client](https://github.com/hmcts/ccd-client) | Azure Artifacts | `com.github.hmcts:ccd-client:4.9.2` -> `com.github.hmcts:core-case-data-store-client:4.9.1.1` |
| [com.github.hmcts:java-logging](https://github.com/hmcts/java-logging) | Azure Artifacts | `com.github.hmcts:java-logging:6.0.1` -> `com.github.hmcts.java-logging:logging:6.1.9` |
| [com.github.hmcts:sscs-common](https://github.com/hmcts/sscs-common) | Azure Artifacts | No tagged version published on Azure yet |
| [com.github.hmcts:fortify-client](https://github.com/hmcts/fortify-client) | Azure Artifacts | `1.2.2` -> `1.4.9` |

### Security Vulnerability Assessment ###

CVE-2024-38820 (Severity: Medium):
Needs Spring Framework bump to `5.3.41`, `6.0.25` or `6.1.14` but versions above `5.3.39` are available only commercially. Needs a Spring Boot 3 migration to resolve.  

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?

```
[x] Yes
[ ] No
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
