### PR TITLE
CVE-2026-22732 - dependency update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -230,6 +230,9 @@ dependencyManagement {
       entry 'log4j-api'
       entry 'log4j-to-slf4j'
     }
+
+    // Latest possible version for Spring Boot 2
+    dependency group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.8.16'
   }
 }
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -2,5 +2,6 @@
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress until = "2026-05-07">
     <cve>CVE-2024-38820</cve>
+    <cve>CVE-2026-22732</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###

CVE-2026-22732

Updates `org.springframework.security:spring-security-crypto` to latest version `5.8.16` (from `5.7.11`) compatible with Spring Boot 2. This is still below the required `5.8.24` version which is only available with Enterprise Support only:
https://spring.io/security/cve-2026-22732 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
