### PR TITLE
SSCSCI-2473 - commons update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -267,7 +267,7 @@ dependencies {
   implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '4.9.1.1'
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '6.3.47'
+  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '6.3.48'
 
   implementation group: 'com.github.mwiede', name: 'jsch', version: '0.2.11'
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,5 +15,7 @@
     <cve>CVE-2026-40973</cve>
     <cve>CVE-2026-40975</cve>
     <cve>CVE-2026-40977</cve>
+    <cve>CVE-2025-15104</cve>
+    <cve>CVE-2026-40974</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###

Update commons to 6.3.48

Suppress 

- CVE-2026-40974 - the fix for this CVE is to update spring to 2.7.33. This is an enterprise support only patch
- CVE-2025-15104 - this is flagging on json-schema-validator@1.5.8. This is a false positive as cve is caused by Nu Html Checker (validator.nu) which we are not using

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
