### PR TITLE
SSCSCI: Update suppressions and java plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'uk.gov.hmcts.java' version '0.12.70'
   id 'com.github.ben-manes.versions' version '0.46.0'
   id 'org.sonarqube' version '6.2.0.5505'
-  id 'org.owasp.dependencycheck' version '12.2.2'
+  id 'org.owasp.dependencycheck' version '12.1.3'
   id "com.gorylenko.gradle-git-properties" version "2.4.1"
   id "io.freefair.lombok" version "8.14"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,10 @@ plugins {
   id 'jacoco'
   id "io.spring.dependency-management" version "1.1.7"
   id 'org.springframework.boot' version '2.7.18'
-  id 'uk.gov.hmcts.java' version '0.12.67'
+  id 'uk.gov.hmcts.java' version '0.12.70'
   id 'com.github.ben-manes.versions' version '0.46.0'
   id 'org.sonarqube' version '6.2.0.5505'
-  id 'org.owasp.dependencycheck' version '12.1.3'
+  id 'org.owasp.dependencycheck' version '12.2.2'
   id "com.gorylenko.gradle-git-properties" version "2.4.1"
   id "io.freefair.lombok" version "8.14"
 }
@@ -225,18 +225,13 @@ dependencyManagement {
     // CVE-2025-48924
     dependency group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
 
-    // CVE-2025-68161
-    // CVE-2026-34478
-    // CVE-2026-34481
-    // CVE-2026-34480
-    dependencySet(group: 'org.apache.logging.log4j', version: '2.25.4') {
-      entry 'log4j-api'
-      entry 'log4j-to-slf4j'
-    }
-
     // Latest possible version for Spring Boot 2
     dependency group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.8.16'
   }
+}
+
+ext {
+  set('log4j2.version', '2.26.0')
 }
 
 def versions = [
@@ -274,7 +269,7 @@ dependencies {
   implementation  group: 'org.json', name: 'json', version: '20240303'
 
   implementation  group: 'commons-io', name: 'commons-io', version: versions.commons_io
-  implementation  group: 'org.elasticsearch', name: 'elasticsearch', version: '7.17.10'
+  implementation  group: 'org.elasticsearch', name: 'elasticsearch', version: '7.17.29'
 
   implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
   implementation group: 'org.apache.commons', name: 'commons-text', version: '1.14.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,7 +15,12 @@
     <cve>CVE-2026-40973</cve>
     <cve>CVE-2026-40975</cve>
     <cve>CVE-2026-40977</cve>
-    <cve>CVE-2025-15104</cve>
     <cve>CVE-2026-40974</cve>
+    <cve>CVE-2025-37731</cve>
+    <cve>CVE-2024-52980</cve>
+    <cve>CVE-2025-68384</cve>
+    <cve>CVE-2025-37727</cve>
+    <cve>CVE-2025-68390</cve>
+    <cve>CVE-2016-1000027</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###

Updates

| Name | Change |
| --- | --- |
| uk.gov.hmcts.java | `0.12.67` -> `0.12.70` |
| org.owasp.dependencycheck | `12.1.3` -> `12.2.2` |
| log4j | `2.25.4` -> `2.26.0` |
| elasticsearch | `7.17.10` -> `7.17.29` |

List of suppressed vulnerabilities

| CVE              | Via                                                                              | Note                                                                                                      |
| ---------------- | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
| CVE-2024-38820   | [Spring Framework](https://github.com/spring-projects/spring-framework) `5.3.39` | Latest version is `7.0.7`. Part of Spring Boot.                                                           |
| CVE-2026-22732   | [Spring Security Crypto](https://spring.io/projects/spring-security) `5.8.16`    | Latest version `7.0.5`. Part of Spring Boot.                                                              |
| CVE-2026-22737   | [Spring Framework](https://github.com/spring-projects/spring-framework) `5.3.39` | Latest version is `7.0.7`. Part of Spring Boot.                                                           |
| CVE-2026-22735   | [Spring Framework](https://github.com/spring-projects/spring-framework) `5.3.39` | Latest version is `7.0.7`. Part of Spring Boot.                                                           |
| CVE-2026-22733   | [Spring Boot](https://spring.io/projects/spring-boot) `2.7.18`                   | Latest version is `4.0.6`. Spring Boot 2 reached End of Life, and needs major update.                     |
| CVE-2026-22740   | [Spring Framework](https://github.com/spring-projects/spring-framework) `5.3.39` | Latest version is `7.0.7`. Part of Spring Boot.                                                           |
| CVE-2026-22741   | [Spring Framework](https://github.com/spring-projects/spring-framework) `5.3.39` | Latest version is `7.0.7`. Part of Spring Boot.                                                           |
| CVE-2026-22745   | [Spring Framework](https://github.com/spring-projects/spring-framework) `5.3.39` | Latest version is `7.0.7`. Part of Spring Boot.                                                           |
| CVE-2026-22746   | [Spring Security Crypto](https://spring.io/projects/spring-security) `5.8.16`    | Latest version `7.0.5`. Part of Spring Boot.                                                              |
| CVE-2026-22748   | [Spring Security Crypto](https://spring.io/projects/spring-security) `5.8.16`    | Latest version `7.0.5`. Part of Spring Boot.                                                              |
| CVE-2026-40972   | [Spring Boot](https://spring.io/projects/spring-boot) `2.7.18`                   | Latest version is `4.0.6`. Spring Boot 2 reached End of Life, and needs major update.                     |
| CVE-2026-40973   | [Spring Boot](https://spring.io/projects/spring-boot) `2.7.18`                   | Latest version is `4.0.6`. Spring Boot 2 reached End of Life, and needs major update.                     |
| CVE-2026-40975   | [Spring Boot](https://spring.io/projects/spring-boot) `2.7.18`                   | Latest version is `4.0.6`. Spring Boot 2 reached End of Life, and needs major update.                     |
| CVE-2026-40977   | [Spring Boot](https://spring.io/projects/spring-boot) `2.7.18`                   | Latest version is `4.0.6`. Spring Boot 2 reached End of Life, and needs major update.                     |
| CVE-2026-40974   | [Spring Boot](https://spring.io/projects/spring-boot) `2.7.18`                   | Latest version is `4.0.6`. Spring Boot 2 reached End of Life, and needs major update.                     |
| CVE-2025-37731   | [Elasticsearch](https://github.com/elastic/elasticsearch) `7.17.29`              | Latest version is `9.4.1` but any version above `v7` requires Spring Boot update due to breaking changes. |
| CVE-2024-52980   | [Elasticsearch](https://github.com/elastic/elasticsearch) `7.17.29`              | Latest version is `9.4.1` but any version above `v7` requires Spring Boot update due to breaking changes. |
| CVE-2025-68384   | [Elasticsearch](https://github.com/elastic/elasticsearch) `7.17.29`              | Latest version is `9.4.1` but any version above `v7` requires Spring Boot update due to breaking changes. |
| CVE-2025-37727   | [Elasticsearch](https://github.com/elastic/elasticsearch) `7.17.29`              | Latest version is `9.4.1` but any version above `v7` requires Spring Boot update due to breaking changes. |
| CVE-2025-68390   | [Elasticsearch](https://github.com/elastic/elasticsearch) `7.17.29`              | Latest version is `9.4.1` but any version above `v7` requires Spring Boot update due to breaking changes. |
| CVE-2016-1000027 | [Spring Framework](https://github.com/spring-projects/spring-framework) `5.3.39` | Latest version is `7.0.7`. Part of Spring Boot.                                                           |


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
