### PR TITLE
suppressions

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -23,5 +23,12 @@
     <cve>CVE-2025-68390</cve>
     <cve>CVE-2016-1000027</cve>
     <cve>CVE-2025-15104</cve>
+    <cve>CVE-2026-41842</cve>
+    <cve>CVE-2026-41849</cve>
+    <cve>CVE-2026-41850</cve>
+    <cve>CVE-2026-41851</cve>
+    <cve>CVE-2026-41840</cve>
+    <cve>CVE-2026-41841</cve>
+    <cve>CVE-2026-41843</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until = "2026-06-07">
+  <suppress until = "2026-07-11">
     <cve>CVE-2024-38820</cve>
     <cve>CVE-2026-22732</cve>
     <cve>CVE-2026-22737</cve>


### PR DESCRIPTION
### Change description ###

Update CVE suppressions date

Add suppressions for below cves: Unable to fix these as I cannot upgrade to fixed spring-framework version 5.3.49 as this is enterprise only. Cannot upgrade to version 6 as this requires spring3 which is a breaking change.

CVE-2026-41842
CVE-2026-41849
CVE-2026-41850
CVE-2026-41851
CVE-2026-41840
CVE-2026-41841
CVE-2026-41843




