### PR TITLE
SSCSCI - sscs common update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -262,7 +262,7 @@ dependencies {
   implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '4.9.1.1'
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '6.3.51'
+  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '6.3.52'
 
   implementation group: 'com.github.mwiede', name: 'jsch', version: '0.2.11'
 

--- a/build.gradle
+++ b/build.gradle
@@ -226,7 +226,7 @@ dependencyManagement {
     dependency group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
 
     // Latest possible version for Spring Boot 2
-    dependency group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.8.26'
+    dependency group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.8.16'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -226,7 +226,7 @@ dependencyManagement {
     dependency group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'
 
     // Latest possible version for Spring Boot 2
-    dependency group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.8.16'
+    dependency group: 'org.springframework.security', name: 'spring-security-crypto', version: '5.8.26'
   }
 }
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -39,6 +39,7 @@
     <cve>CVE-2026-41845</cve>
     <cve>CVE-2026-40988</cve>
     <cve>CVE-2026-41838</cve>
-
+    <cve>CVE-2026-41003</cve>
+    <cve>CVE-2026-41694</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -30,5 +30,15 @@
     <cve>CVE-2026-41840</cve>
     <cve>CVE-2026-41841</cve>
     <cve>CVE-2026-41843</cve>
+    <cve>CVE-2026-41844</cve>
+    <cve>CVE-2026-41853</cve>
+    <cve>CVE-2026-41852</cve>
+    <cve>CVE-2026-41848</cve>
+    <cve>CVE-2026-41847</cve>
+    <cve>CVE-2026-41846</cve>
+    <cve>CVE-2026-41845</cve>
+    <cve>CVE-2026-40988</cve>
+    <cve>CVE-2026-41838</cve>
+
   </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###

Update sscs-common

Suppress a number of cves caused by spring framework and spring security. These packages are already on the latest version possible that is compatible with Spring2:
CVE-2026-41844
CVE-2026-41853
CVE-2026-41852
CVE-2026-41848
CVE-2026-41847
CVE-2026-41846
CVE-2026-41845
CVE-2026-40988
CVE-2026-41838
CVE-2026-41003
CVE-2026-41694

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
