### PR TITLE
CVE Suppressions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ ext {
 }
 
 def versions = [
-  jackson : '2.17.2',
+  jackson : '2.21.4',
   commons_io : '2.22.0'
 ]
 
@@ -275,7 +275,7 @@ dependencies {
   implementation group: 'org.apache.commons', name: 'commons-text', version: '1.14.0'
 
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: versions.jackson
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: versions.jackson
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.22'
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jackson
   implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: versions.jackson
   implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: versions.jackson

--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ ext {
 }
 
 def versions = [
-  jackson : '2.17.2',
+  jackson : '2.22.0',
   commons_io : '2.22.0'
 ]
 
@@ -275,7 +275,7 @@ dependencies {
   implementation group: 'org.apache.commons', name: 'commons-text', version: '1.14.0'
 
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: versions.jackson
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: versions.jackson
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.22'
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jackson
   implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: versions.jackson
   implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: versions.jackson

--- a/build.gradle
+++ b/build.gradle
@@ -276,7 +276,7 @@ dependencies {
 
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: versions.jackson
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.22'
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jackson
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.21.4'
   implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: versions.jackson
   implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: versions.jackson
   implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names', version: versions.jackson

--- a/build.gradle
+++ b/build.gradle
@@ -235,7 +235,7 @@ ext {
 }
 
 def versions = [
-  jackson : '2.22.0',
+  jackson : '2.17.2',
   commons_io : '2.22.0'
 ]
 
@@ -275,8 +275,8 @@ dependencies {
   implementation group: 'org.apache.commons', name: 'commons-text', version: '1.14.0'
 
   implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: versions.jackson
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.22'
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.21.4'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: versions.jackson
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jackson
   implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: versions.jackson
   implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: versions.jackson
   implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names', version: versions.jackson

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -41,5 +41,9 @@
     <cve>CVE-2026-41838</cve>
     <cve>CVE-2026-41003</cve>
     <cve>CVE-2026-41694</cve>
+    <cve>CVE-2026-54515</cve>
+    <cve>CVE-2026-41855</cve>
+    <cve>CVE-2026-47838</cve>
+    <cve>CVE-2026-41706</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###

Upgrade jackson libraries to 2.21.4 and jackson annotations to 2.22

Suppress CVE-2026-54515 as fix (jackson data bind 2.21.5 is not yet released)

Suppress CVE-2026-41855, CVE-2026-47838, CVE-2026-41706 as we are already on latest version of spring framework and spring security that we can be on spring 2


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
