### PR TITLE
Suppress CVEs

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until = "2026-07-11">
+  <suppress until = "2026-08-07">
     <cve>CVE-2024-38820</cve>
     <cve>CVE-2026-22732</cve>
     <cve>CVE-2026-22737</cve>
@@ -45,5 +45,7 @@
     <cve>CVE-2026-41855</cve>
     <cve>CVE-2026-47838</cve>
     <cve>CVE-2026-41706</cve>
+    <cve>CVE-2026-54428</cve>
+    <cve>CVE-2026-54399</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###

Suppress CVE 2026-54428 and CVE 2026-54399 caused by HttpComponents Core (5.4.2 and earlier). Caseloader is using v 4.5.14-16 and Version 4 is a different Maven artifact. The CVEs on this are false positive.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
