### PR TITLE
SSCSCI-2658

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -231,7 +231,7 @@ dependencyManagement {
 }
 
 ext {
-  set('log4j2.version', '2.26.0')
+  set('log4j2.version', '2.26.1')
 }
 
 def versions = [

--- a/build.gradle
+++ b/build.gradle
@@ -262,7 +262,7 @@ dependencies {
   implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '4.9.1.1'
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
-  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '6.3.57'
+  implementation group: 'com.github.hmcts', name: 'sscs-common', version: '6.3.58'
 
   implementation group: 'com.github.mwiede', name: 'jsch', version: '0.2.11'
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -47,5 +47,6 @@
     <cve>CVE-2026-41706</cve>
     <cve>CVE-2026-54428</cve>
     <cve>CVE-2026-54399</cve>
+    <cve>CVE-2026-41839</cve>
   </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/ccd/UpdateCcdAppellantData.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/ccd/UpdateCcdAppellantData.java
@@ -27,6 +27,7 @@ class UpdateCcdAppellantData {
                     .identity(gapsAppellant.getAppointee().getIdentity())
                     .address(gapsAppellant.getAppointee().getAddress())
                     .build())
+                .confidentialityRequired(gapsAppellant.getConfidentialityRequired())
                 .confidentialityRequirement(gapsAppellant.getConfidentialityRequirement())
                 .isAddressSameAsAppointee(gapsAppellant.getIsAddressSameAsAppointee())
                 .isAppointee(gapsAppellant.getIsAppointee())

--- a/src/main/java/uk/gov/hmcts/reform/sscs/services/ccd/UpdateCcdAppellantData.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/services/ccd/UpdateCcdAppellantData.java
@@ -27,7 +27,7 @@ class UpdateCcdAppellantData {
                     .identity(gapsAppellant.getAppointee().getIdentity())
                     .address(gapsAppellant.getAppointee().getAddress())
                     .build())
-                .confidentialityRequired(gapsAppellant.getConfidentialityRequired())
+                .confidentialityRequirement(gapsAppellant.getConfidentialityRequirement())
                 .isAddressSameAsAppointee(gapsAppellant.getIsAddressSameAsAppointee())
                 .isAppointee(gapsAppellant.getIsAppointee())
                 .role(gapsAppellant.getRole())

--- a/src/test/java/uk/gov/hmcts/reform/sscs/services/ccd/UpdateCcdAppellantDataTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/services/ccd/UpdateCcdAppellantDataTest.java
@@ -337,7 +337,7 @@ public class UpdateCcdAppellantDataTest {
                 .build())
             .isAppointee("No")
             .isAddressSameAsAppointee("Yes")
-            .confidentialityRequired(YesNo.NO)
+            .confidentialityRequirement(YesNoUndetermined.NO)
             .role(Role.builder().build())
             .build();
 
@@ -367,8 +367,8 @@ public class UpdateCcdAppellantDataTest {
             equalTo("No"));
         assertThat(existingCcdCaseData.getAppeal().getAppellant().getIsAddressSameAsAppointee(),
             equalTo("Yes"));
-        assertThat(existingCcdCaseData.getAppeal().getAppellant().getConfidentialityRequired(),
-            equalTo(YesNo.NO));
+        assertThat(existingCcdCaseData.getAppeal().getAppellant().getConfidentialityRequirement(),
+            equalTo(YesNoUndetermined.NO));
         assertNotNull(existingCcdCaseData.getAppeal().getAppellant().getRole());
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCSCI-2658


### Change description ###
Update sscs-common and log4j2. Updated confidentiality field for appellant.
Suppressing CVE-2026-41839 as sscs-case-loader is not a WebFlux project so it's unaffected by the vulnerability.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
